### PR TITLE
eclipse: remove useless target/classes **/META-INF/services/* from POM (fixes #352)

### DIFF
--- a/jetcd-common/pom.xml
+++ b/jetcd-common/pom.xml
@@ -47,15 +47,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>target/classes</directory>
-                <includes>
-                    <include>**/META-INF/services/*</include>
-                </includes>
-            </resource>
-        </resources>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -130,15 +130,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>target/classes</directory>
-                <includes>
-                    <include>**/META-INF/services/*</include>
-                </includes>
-            </resource>
-        </resources>
-
         <extensions>
             <extension>
                 <groupId>kr.motd.maven</groupId>

--- a/jetcd-resolver/pom.xml
+++ b/jetcd-resolver/pom.xml
@@ -69,15 +69,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>target/classes</directory>
-                <includes>
-                    <include>**/META-INF/services/*</include>
-                </includes>
-            </resource>
-        </resources>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
part of overall https://github.com/coreos/jetcd/issues/340 (but fully fixed, yet)