### PR TITLE
eclipse: add more M2E ignore lifecycle mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,6 +561,33 @@
                             <ignore></ignore>
                           </action>
                         </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.xolstice.maven.plugins</groupId>
+                            <artifactId>protobuf-maven-plugin</artifactId>
+                            <versionRange>[0.5.1,)</versionRange>
+                            <goals>
+                              <goal>compile</goal>
+                              <goal>compile-custom</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.apache.servicemix.tooling</groupId>
+                            <artifactId>depends-maven-plugin</artifactId>
+                            <versionRange>[1.4.0,)</versionRange>
+                            <goals>
+                              <goal>generate-depends-file</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
                       </pluginExecutions>
                     </lifecycleMappingMetadata>
                   </configuration>


### PR DESCRIPTION
re. https://github.com/coreos/jetcd/issues/340 (but not fixed, yet)