### PR TITLE
eclipse: Fix build-helper-maven-plugin target/generated-sources

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -173,7 +173,8 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${basedir}/target/generated-sources</source>
+                                <source>${basedir}/target/generated-sources/protobuf/grpc-java</source>
+                                <source>${basedir}/target/generated-sources/protobuf/java</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This seems to have always been wrong - the protobuf-maven-plugin
generates under target/generated-sources/protobuf/grpc-java and
target/generated-sources/protobuf/java but not root
target/generated-sources.

I suspect it always worked in the build nevertheless, because the
protobuf-maven-plugin probably adds its output folders as source folders
automatically itself - so it was all good.  The
build-helper-maven-plugin configuration (as is) essentially had no real
effect.

Under M2E in Eclipse however, after adding a M2E ignore lifecycle
mappings for the protobuf-maven-plugin in the previous commit (to solve
other problems), the generated sources were no longer added as source
folders to the build path.  With this change, they are again.  It
assumes one first ran a mvn build on this CLI.

Related to overall https://github.com/etcd-io/jetcd/issues/340 effort.