### PR TITLE
eclipse: run os-maven-plugin as Maven plugin instead of extension

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -130,15 +130,22 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
+        <plugins>
+            <plugin>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
                 <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>detect</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-        <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -550,6 +550,19 @@
                       <pluginExecutions>
                         <pluginExecution>
                           <pluginExecutionFilter>
+                            <groupId>kr.motd.maven</groupId>
+                            <artifactId>os-maven-plugin</artifactId>
+                            <versionRange>[1.6.0,)</versionRange>
+                            <goals>
+                              <goal>detect</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <execute></execute>
+                          </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
                             <groupId>org.commonjava.maven.plugins</groupId>
                             <artifactId>directory-maven-plugin</artifactId>
                             <versionRange>[0.3.1,)</versionRange>


### PR DESCRIPTION
This lets it run in Eclipse under M2E as well, so that the dependency
netty-tcnative-boringssl-static with can be resolved with its
<classifier>${os.detected.classifier}.

see also https://github.com/trustin/os-maven-plugin/issues/34

This concludes and fully fixes
https://github.com/etcd-io/jetcd/issues/340 - one can now (cleanly)
import jetcd into an Eclipse workspace using M2E - yay!