### PR TITLE
deprecate methods in ByteSequence which are problematic re. encoding

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
@@ -75,38 +75,12 @@ public final class ByteSequence {
 
   /**
    * Create new ByteSequence from a String.
-   * @deprecated Use {@link #from(String, Charset)} instead.
-   */
-  @Deprecated
-  public static ByteSequence from(String source) {
-    return from(source, Charset.defaultCharset());
-  }
-
-  /**
-   * Create new ByteSequence from a String.
    * @param source input String
    * @param charset the character set to use to transform the String into bytes
    * @return the ByteSequence
    */
   public static ByteSequence from(String source, Charset charset) {
     byte[] bytes = source.getBytes(charset);
-
-    return new ByteSequence(ByteString.copyFrom(bytes));
-  }
-
-  /**
-   * Create new ByteSequence from a CharSequence.
-   *
-   * @deprecated Do not use this method, because it assumes all characters in the
-   *             CharSequence are bytes (which they may well not necessarily be;
-   *             char is 2 bytes). It cannot handle encoding correctly.
-   */
-  @Deprecated
-  public static ByteSequence from(CharSequence source) {
-    byte[] bytes = new byte[source.length()];
-    for (int i = source.length() - 1; i >= 0; i--) {
-      bytes[i] = (byte)source.charAt(i);
-    }
 
     return new ByteSequence(ByteString.copyFrom(bytes));
   }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
@@ -73,18 +73,35 @@ public final class ByteSequence {
     return byteString.toByteArray();
   }
 
+  /**
+   * Create new ByteSequence from a String.
+   * @deprecated Use {@link #from(String, Charset)} instead.
+   */
+  @Deprecated
   public static ByteSequence from(String source) {
-    byte[] bytes = source.getBytes();
-
-    return new ByteSequence(ByteString.copyFrom(bytes));
+    return from(source, Charset.defaultCharset());
   }
 
+  /**
+   * Create new ByteSequence from a String.
+   * @param source input String
+   * @param charset the character set to use to transform the String into bytes
+   * @return the ByteSequence
+   */
   public static ByteSequence from(String source, Charset charset) {
     byte[] bytes = source.getBytes(charset);
 
     return new ByteSequence(ByteString.copyFrom(bytes));
   }
 
+  /**
+   * Create new ByteSequence from a CharSequence.
+   *
+   * @deprecated Do not use this method, because it assumes all characters in the
+   *             CharSequence are bytes (which they may well not necessarily be;
+   *             char is 2 bytes). It cannot handle encoding correctly.
+   */
+  @Deprecated
   public static ByteSequence from(CharSequence source) {
     byte[] bytes = new byte[source.length()];
     for (int i = source.length() - 1; i >= 0; i--) {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/AuthClientTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/AuthClientTest.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.internal.impl;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Auth;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
@@ -42,28 +43,28 @@ public class AuthClientTest {
 
   private static final EtcdCluster CLUSTER = EtcdClusterFactory.buildCluster("auth-etcd", 1, false);
 
-  private ByteSequence rootRolekeyRangeBegin = ByteSequence.from("root");
-  private ByteSequence rootkeyRangeEnd = ByteSequence.from("root1");
+  private final ByteSequence rootRolekeyRangeBegin = ByteSequence.from("root", Charsets.UTF_8);
+  private final ByteSequence rootkeyRangeEnd = ByteSequence.from("root1", Charsets.UTF_8);
 
-  private ByteSequence userRolekeyRangeBegin = ByteSequence.from("foo");
-  private ByteSequence userRolekeyRangeEnd = ByteSequence.from("foo1");
+  private final ByteSequence userRolekeyRangeBegin = ByteSequence.from("foo", Charsets.UTF_8);
+  private final ByteSequence userRolekeyRangeEnd = ByteSequence.from("foo1", Charsets.UTF_8);
 
-  private ByteSequence rootRoleKey = ByteSequence.from("root");
-  private ByteSequence rootRoleValue = ByteSequence.from("b");
+  private final ByteSequence rootRoleKey = ByteSequence.from("root", Charsets.UTF_8);
+  private final ByteSequence rootRoleValue = ByteSequence.from("b", Charsets.UTF_8);
 
-  private ByteSequence userRoleKey = ByteSequence.from("foo");
-  private ByteSequence userRoleValue = ByteSequence.from("bar");
-
-
-  private ByteSequence root = ByteSequence.from("root");
-  private ByteSequence rootPass = ByteSequence.from("123");
-  private ByteSequence rootRole = ByteSequence.from("root");
+  private final ByteSequence userRoleKey = ByteSequence.from("foo", Charsets.UTF_8);
+  private final ByteSequence userRoleValue = ByteSequence.from("bar", Charsets.UTF_8);
 
 
-  private ByteSequence user = ByteSequence.from("user");
-  private ByteSequence userPass = ByteSequence.from("userPass");
-  private ByteSequence userNewPass = ByteSequence.from("newUserPass");
-  private ByteSequence userRole = ByteSequence.from("userRole");
+  private final ByteSequence root = ByteSequence.from("root", Charsets.UTF_8);
+  private final ByteSequence rootPass = ByteSequence.from("123", Charsets.UTF_8);
+  private final ByteSequence rootRole = ByteSequence.from("root", Charsets.UTF_8);
+
+
+  private final ByteSequence user = ByteSequence.from("user", Charsets.UTF_8);
+  private final ByteSequence userPass = ByteSequence.from("userPass", Charsets.UTF_8);
+  private final ByteSequence userNewPass = ByteSequence.from("newUserPass", Charsets.UTF_8);
+  private final ByteSequence userRole = ByteSequence.from("userRole", Charsets.UTF_8);
 
   private Client userClient;
   private Client rootClient;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/ClientConnectionManagerTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/ClientConnectionManagerTest.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.internal.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.etcd.jetcd.data.ByteSequence;
@@ -63,7 +64,7 @@ public class ClientConnectionManagerTest {
       });
 
     try (Client client = builder.build()) {
-      client.getKVClient().put(ByteSequence.from("sample_key"), ByteSequence.from("sample_key"));
+      client.getKVClient().put(ByteSequence.from("sample_key", Charsets.UTF_8), ByteSequence.from("sample_key", Charsets.UTF_8));
       latch.await(1, TimeUnit.MINUTES);
     }
   }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/KVTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/KVTest.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.internal.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.Txn;
 import io.etcd.jetcd.data.ByteSequence;
@@ -49,11 +50,11 @@ public class KVTest {
   private static final EtcdCluster CLUSTER = EtcdClusterFactory.buildCluster("etcd-kv", 3 ,false);
   private static KV kvClient;
 
-  private static final ByteSequence SAMPLE_KEY = ByteSequence.from("sample_key");
-  private static final ByteSequence SAMPLE_VALUE = ByteSequence.from("sample_value");
-  private static final ByteSequence SAMPLE_KEY_2 = ByteSequence.from("sample_key2");
-  private static final ByteSequence SAMPLE_VALUE_2 = ByteSequence.from("sample_value2");
-  private static final ByteSequence SAMPLE_KEY_3 = ByteSequence.from("sample_key3");
+  private static final ByteSequence SAMPLE_KEY = ByteSequence.from("sample_key", Charsets.UTF_8);
+  private static final ByteSequence SAMPLE_VALUE = ByteSequence.from("sample_value", Charsets.UTF_8);
+  private static final ByteSequence SAMPLE_KEY_2 = ByteSequence.from("sample_key2", Charsets.UTF_8);
+  private static final ByteSequence SAMPLE_VALUE_2 = ByteSequence.from("sample_value2", Charsets.UTF_8);
+  private static final ByteSequence SAMPLE_KEY_3 = ByteSequence.from("sample_key3", Charsets.UTF_8);
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -111,10 +112,10 @@ public class KVTest {
     GetOption option = GetOption.newBuilder()
         .withSortField(SortTarget.KEY)
         .withSortOrder(SortOrder.DESCEND)
-        .withPrefix(ByteSequence.from(prefix))
+        .withPrefix(ByteSequence.from(prefix, Charsets.UTF_8))
         .build();
     CompletableFuture<GetResponse> getFeature = kvClient
-        .get(ByteSequence.from(prefix), option);
+        .get(ByteSequence.from(prefix, Charsets.UTF_8), option);
     GetResponse response = getFeature.get();
 
     assertEquals(numPrefix, response.getKvs().size());
@@ -144,7 +145,7 @@ public class KVTest {
   @Test
   public void testGetAndDeleteWithPrefix() throws Exception {
     String prefix = TestUtil.randomString();
-    ByteSequence key = ByteSequence.from(prefix);
+    ByteSequence key = ByteSequence.from(prefix, Charsets.UTF_8);
     int numPrefixes = 10;
 
     putKeysWithPrefix(prefix, numPrefixes);
@@ -166,19 +167,19 @@ public class KVTest {
   private void putKeysWithPrefix(String prefix, int numPrefixes)
       throws ExecutionException, InterruptedException {
     for (int i = 0; i < numPrefixes; i++) {
-      ByteSequence key = ByteSequence.from(prefix + i);
-      ByteSequence value = ByteSequence.from("" + i);
+      ByteSequence key = ByteSequence.from(prefix + i, Charsets.UTF_8);
+      ByteSequence value = ByteSequence.from("" + i, Charsets.UTF_8);
       kvClient.put(key, value).get();
     }
   }
 
   @Test
   public void testTxn() throws Exception {
-    ByteSequence sampleKey = ByteSequence.from("txn_key");
-    ByteSequence sampleValue = ByteSequence.from("xyz");
-    ByteSequence cmpValue = ByteSequence.from("abc");
-    ByteSequence putValue = ByteSequence.from("XYZ");
-    ByteSequence putValueNew = ByteSequence.from("ABC");
+    ByteSequence sampleKey = ByteSequence.from("txn_key", Charsets.UTF_8);
+    ByteSequence sampleValue = ByteSequence.from("xyz", Charsets.UTF_8);
+    ByteSequence cmpValue = ByteSequence.from("abc", Charsets.UTF_8);
+    ByteSequence putValue = ByteSequence.from("XYZ", Charsets.UTF_8);
+    ByteSequence putValueNew = ByteSequence.from("ABC", Charsets.UTF_8);
     // put the original txn key value pair
     kvClient.put(sampleKey, sampleValue).get();
 
@@ -198,11 +199,11 @@ public class KVTest {
 
   @Test
   public void testNestedTxn() throws Exception {
-    ByteSequence foo = ByteSequence.from("txn_foo");
-    ByteSequence bar = ByteSequence.from("txn_bar");
-    ByteSequence barz = ByteSequence.from("txn_barz");
-    ByteSequence abc = ByteSequence.from("txn_abc");
-    ByteSequence oneTwoThree = ByteSequence.from("txn_123");
+    ByteSequence foo = ByteSequence.from("txn_foo", Charsets.UTF_8);
+    ByteSequence bar = ByteSequence.from("txn_bar", Charsets.UTF_8);
+    ByteSequence barz = ByteSequence.from("txn_barz", Charsets.UTF_8);
+    ByteSequence abc = ByteSequence.from("txn_abc", Charsets.UTF_8);
+    ByteSequence oneTwoThree = ByteSequence.from("txn_123", Charsets.UTF_8);
 
     Txn txn = kvClient.txn();
     Cmp cmp = new Cmp(foo, Cmp.Op.EQUAL, CmpTarget.version(0));

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/LeaseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/LeaseTest.java
@@ -17,6 +17,7 @@ package io.etcd.jetcd.internal.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.Lease;
@@ -48,9 +49,9 @@ public class LeaseTest {
   private Client client;
   private Lease leaseClient;
 
-  private static final ByteSequence KEY = ByteSequence.from("foo");
-  private static final ByteSequence KEY_2 = ByteSequence.from("foo2");
-  private static final ByteSequence VALUE = ByteSequence.from("bar");
+  private static final ByteSequence KEY = ByteSequence.from("foo", Charsets.UTF_8);
+  private static final ByteSequence KEY_2 = ByteSequence.from("foo2", Charsets.UTF_8);
+  private static final ByteSequence VALUE = ByteSequence.from("bar", Charsets.UTF_8);
 
   @BeforeClass
   public static void beforeClass() {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/LockTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/LockTest.java
@@ -15,6 +15,7 @@
  */
 package io.etcd.jetcd.internal.impl;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Lease;
 import io.etcd.jetcd.Lock;
@@ -46,7 +47,7 @@ public class LockTest {
   private Assertion test;
   private Set<ByteSequence> locksToRelease;
 
-  private static final ByteSequence SAMPLE_NAME = ByteSequence.from("sample_name");
+  private static final ByteSequence SAMPLE_NAME = ByteSequence.from("sample_name", Charsets.UTF_8);
 
   @BeforeTest
   public void setUp() throws Exception {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/SslTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/SslTest.java
@@ -17,6 +17,7 @@ package io.etcd.jetcd.internal.impl;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.data.ByteSequence;
@@ -35,8 +36,8 @@ public class SslTest {
 
   @Test(timeout = 5000)
   public void testSimpleSllSetup() throws Exception {
-    final ByteSequence key = ByteSequence.from(TestUtil.randomString());
-    final ByteSequence val = ByteSequence.from(TestUtil.randomString());
+    final ByteSequence key = ByteSequence.from(TestUtil.randomString(), Charsets.UTF_8);
+    final ByteSequence val = ByteSequence.from(TestUtil.randomString(), Charsets.UTF_8);
     final String capath = System.getProperty("ssl.cert.capath");
     final String authority = System.getProperty("ssl.cert.authority", TestConstants.DEFAULT_SSL_AUTHORITY);
     final String endpoints = System.getProperty("ssl.cert.endpoints", clusterResource.cluster().getClientEndpoints().get(0));

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/TestUtil.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/TestUtil.java
@@ -15,6 +15,7 @@
  */
 package io.etcd.jetcd.internal.impl;
 
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.data.ByteSequence;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -30,7 +31,7 @@ public class TestUtil {
   }
 
   public static ByteSequence randomByteSequence() {
-    return ByteSequence.from(randomString());
+    return ByteSequence.from(randomString(), Charsets.UTF_8);
   }
 
   public static int findNextAvailablePort() throws IOException {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/WatchTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/WatchTest.java
@@ -16,6 +16,7 @@
 package io.etcd.jetcd.internal.impl;
 
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.etcd.jetcd.Client;
@@ -65,8 +66,8 @@ public class WatchTest {
 
   @Test
   public void testWatchOnPut() throws ExecutionException, InterruptedException {
-    ByteSequence key = ByteSequence.from(TestUtil.randomString());
-    ByteSequence value = ByteSequence.from("value");
+    ByteSequence key = TestUtil.randomByteSequence();
+    ByteSequence value = ByteSequence.from("value", UTF_8);
     try (Watcher watcher = watchClient.watch(key)) {
       kvClient.put(key, value).get();
 
@@ -79,8 +80,8 @@ public class WatchTest {
 
   @Test
   public void testWatchOnDelete() throws ExecutionException, InterruptedException {
-    ByteSequence key = ByteSequence.from(TestUtil.randomString());
-    ByteSequence value = ByteSequence.from("value");
+    ByteSequence key = TestUtil.randomByteSequence();
+    ByteSequence value = ByteSequence.from("value", UTF_8);
     kvClient.put(key, value).get();
     try (Watcher watcher = watchClient.watch(key)) {
       kvClient.delete(key);

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/WatchUnitTest.java
@@ -15,6 +15,7 @@
  */
 package io.etcd.jetcd.internal.impl;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -62,7 +63,7 @@ import org.mockito.junit.MockitoRule;
  */
 public class WatchUnitTest {
 
-  private final static ByteSequence KEY = ByteSequence.from("test_key");
+  private final static ByteSequence KEY = ByteSequence.from("test_key", UTF_8);
   @Rule
   public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();
   @Rule

--- a/jetcd-core/src/test/java/io/etcd/jetcd/op/TxnTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/op/TxnTest.java
@@ -15,6 +15,7 @@
  */
 package io.etcd.jetcd.op;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.etcd.jetcd.data.ByteSequence;
@@ -23,10 +24,10 @@ import org.junit.Test;
 
 public class TxnTest {
 
-  final Cmp CMP = new Cmp(ByteSequence.from("key"), Cmp.Op.GREATER,
-      CmpTarget.value(ByteSequence.from("value")));
+  final Cmp CMP = new Cmp(ByteSequence.from("key", UTF_8), Cmp.Op.GREATER,
+      CmpTarget.value(ByteSequence.from("value", UTF_8)));
   final Op OP = Op
-      .put(ByteSequence.from("key2"), ByteSequence.from("value2"), PutOption.DEFAULT);
+      .put(ByteSequence.from("key2", UTF_8), ByteSequence.from("value2", UTF_8), PutOption.DEFAULT);
 
   @Test
   public void testIfs() {

--- a/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandGet.java
+++ b/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandGet.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.examples.jetcdctl;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.data.ByteSequence;
 import io.etcd.jetcd.kv.GetResponse;
@@ -31,15 +32,15 @@ class CommandGet {
   private static final Logger LOGGER = LoggerFactory.getLogger(CommandGet.class);
 
   @Parameter(arity = 1, description = "<key>")
-  private String key = "";
+  private final String key = "";
 
   @Parameter(names = "--rev", description = "Specify the kv revision")
-  private Long rev = 0L;
+  private final Long rev = 0L;
 
   // get executes the "get" command.
   void get(Client client) throws Exception {
     GetResponse getResponse = client.getKVClient().get(
-        ByteSequence.from(key),
+        ByteSequence.from(key, Charsets.UTF_8),
         GetOption.newBuilder().withRevision(rev).build()
     ).get();
     if (getResponse.getKvs().isEmpty()) {

--- a/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandPut.java
+++ b/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandPut.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.examples.jetcdctl;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.data.ByteSequence;
 import java.util.List;
@@ -35,8 +36,8 @@ class CommandPut {
   // put executes the "put" command.
   void put(Client client) throws Exception {
     client.getKVClient().put(
-        ByteSequence.from(keyValue.get(0)),
-        ByteSequence.from(keyValue.get(1))
+        ByteSequence.from(keyValue.get(0), Charsets.UTF_8),
+        ByteSequence.from(keyValue.get(1), Charsets.UTF_8)
     ).get();
     LOGGER.info("OK");
   }

--- a/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandWatch.java
+++ b/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandWatch.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.examples.jetcdctl;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Watch.Watcher;
 import io.etcd.jetcd.data.ByteSequence;
@@ -43,7 +44,7 @@ class CommandWatch {
     Watcher watcher = null;
     try {
       watcher = client.getWatchClient().watch(
-          ByteSequence.from(key),
+          ByteSequence.from(key, Charsets.UTF_8),
           WatchOption.newBuilder().withRevision(rev).build()
       );
 

--- a/jetcd-examples/jetcd-watch-example/src/main/java/io/etcd/jetcd/examples/watch/Main.java
+++ b/jetcd-examples/jetcd-watch-example/src/main/java/io/etcd/jetcd/examples/watch/Main.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.examples.watch;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.data.ByteSequence;
@@ -42,7 +43,7 @@ public class Main {
 
     try (Client client = Client.builder().endpoints(cmd.endpoints).build();
          Watch watch = client.getWatchClient();
-         Watch.Watcher watcher = watch.watch(ByteSequence.from(cmd.key))) {
+         Watch.Watcher watcher = watch.watch(ByteSequence.from(cmd.key, Charsets.UTF_8))) {
       for (int i = 0; i < cmd.maxEvents; i++) {
         LOGGER.info("Watching for key={}", cmd.key);
         WatchResponse response = watcher.listen();
@@ -71,7 +72,7 @@ public class Main {
         names = { "-e", "--endpoints" },
         description = "the etcd endpoints"
     )
-    private List<String> endpoints = new ArrayList<>();
+    private final List<String> endpoints = new ArrayList<>();
 
     @Parameter(
         required = true,
@@ -84,6 +85,6 @@ public class Main {
         names = { "-m", "--max-events" },
         description = "the maximum number of events to receive"
     )
-    private Integer maxEvents = Integer.MAX_VALUE;
+    private final Integer maxEvents = Integer.MAX_VALUE;
   }
 }

--- a/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/ClientService.java
+++ b/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/ClientService.java
@@ -27,6 +27,7 @@ import io.etcd.jetcd.Maintenance;
 import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.data.ByteSequence;
 import io.etcd.jetcd.resolver.URIResolver;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
 import org.osgi.service.component.annotations.Activate;
@@ -60,34 +61,42 @@ public class ClientService implements Client {
     this.resolvers = new HashSet<>();
   }
 
+  @Override
   public Auth getAuthClient() {
     return delegate.getAuthClient();
   }
 
+  @Override
   public KV getKVClient() {
     return delegate.getKVClient();
   }
 
+  @Override
   public Cluster getClusterClient() {
     return delegate.getClusterClient();
   }
 
+  @Override
   public Maintenance getMaintenanceClient() {
     return delegate.getMaintenanceClient();
   }
 
+  @Override
   public Lease getLeaseClient() {
     return delegate.getLeaseClient();
   }
 
+  @Override
   public Watch getWatchClient() {
     return delegate.getWatchClient();
   }
 
+  @Override
   public Lock getLockClient() {
     return delegate.getLockClient();
   }
 
+  @Override
   public void close() {
     throw new UnsupportedOperationException("");
   }
@@ -104,10 +113,10 @@ public class ClientService implements Client {
     builder.uriResolverLoader(() -> resolvers);
 
     if (config.user() != null) {
-      builder.user(ByteSequence.from(config.user()));
+      builder.user(ByteSequence.from(config.user(), Charset.forName(config.charset())));
     }
     if (config.password() != null) {
-      builder.password(ByteSequence.from(config.password()));
+      builder.password(ByteSequence.from(config.password(), Charset.forName(config.charset())));
     }
 
     this.delegate = builder.build();
@@ -148,5 +157,8 @@ public class ClientService implements Client {
 
     @AttributeDefinition(required = false, type = AttributeType.PASSWORD)
     String password();
+
+    @AttributeDefinition(required = false, type = AttributeType.STRING, defaultValue = "UTF-8", description = "Character Set used for user and password")
+    String charset();
   }
 }


### PR DESCRIPTION
includes JavaDoc with explanations.

Fixes #342 (again)