### PR TITLE
Remove toStringUtf8() method in ByteSequence

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
@@ -57,10 +57,6 @@ public final class ByteSequence {
     return hashVal;
   }
 
-  public String toStringUtf8() {
-    return byteString.toStringUtf8();
-  }
-
   public String toString(Charset charset) {
     return byteString.toString(charset);
   }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/AuthClientTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/AuthClientTest.java
@@ -15,10 +15,10 @@
  */
 package io.etcd.jetcd.internal.impl;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.google.common.base.Charsets;
 import io.etcd.jetcd.Auth;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
@@ -43,28 +43,28 @@ public class AuthClientTest {
 
   private static final EtcdCluster CLUSTER = EtcdClusterFactory.buildCluster("auth-etcd", 1, false);
 
-  private final ByteSequence rootRolekeyRangeBegin = ByteSequence.from("root", Charsets.UTF_8);
-  private final ByteSequence rootkeyRangeEnd = ByteSequence.from("root1", Charsets.UTF_8);
+  private final ByteSequence rootRolekeyRangeBegin = ByteSequence.from("root", UTF_8);
+  private final ByteSequence rootkeyRangeEnd = ByteSequence.from("root1", UTF_8);
 
-  private final ByteSequence userRolekeyRangeBegin = ByteSequence.from("foo", Charsets.UTF_8);
-  private final ByteSequence userRolekeyRangeEnd = ByteSequence.from("foo1", Charsets.UTF_8);
+  private final ByteSequence userRolekeyRangeBegin = ByteSequence.from("foo", UTF_8);
+  private final ByteSequence userRolekeyRangeEnd = ByteSequence.from("foo1", UTF_8);
 
-  private final ByteSequence rootRoleKey = ByteSequence.from("root", Charsets.UTF_8);
-  private final ByteSequence rootRoleValue = ByteSequence.from("b", Charsets.UTF_8);
+  private final ByteSequence rootRoleKey = ByteSequence.from("root", UTF_8);
+  private final ByteSequence rootRoleValue = ByteSequence.from("b", UTF_8);
 
-  private final ByteSequence userRoleKey = ByteSequence.from("foo", Charsets.UTF_8);
-  private final ByteSequence userRoleValue = ByteSequence.from("bar", Charsets.UTF_8);
-
-
-  private final ByteSequence root = ByteSequence.from("root", Charsets.UTF_8);
-  private final ByteSequence rootPass = ByteSequence.from("123", Charsets.UTF_8);
-  private final ByteSequence rootRole = ByteSequence.from("root", Charsets.UTF_8);
+  private final ByteSequence userRoleKey = ByteSequence.from("foo", UTF_8);
+  private final ByteSequence userRoleValue = ByteSequence.from("bar", UTF_8);
 
 
-  private final ByteSequence user = ByteSequence.from("user", Charsets.UTF_8);
-  private final ByteSequence userPass = ByteSequence.from("userPass", Charsets.UTF_8);
-  private final ByteSequence userNewPass = ByteSequence.from("newUserPass", Charsets.UTF_8);
-  private final ByteSequence userRole = ByteSequence.from("userRole", Charsets.UTF_8);
+  private final ByteSequence root = ByteSequence.from("root", UTF_8);
+  private final ByteSequence rootPass = ByteSequence.from("123", UTF_8);
+  private final ByteSequence rootRole = ByteSequence.from("root", UTF_8);
+
+
+  private final ByteSequence user = ByteSequence.from("user", UTF_8);
+  private final ByteSequence userPass = ByteSequence.from("userPass", UTF_8);
+  private final ByteSequence userNewPass = ByteSequence.from("newUserPass", UTF_8);
+  private final ByteSequence userRole = ByteSequence.from("userRole", UTF_8);
 
   private Client userClient;
   private Client rootClient;
@@ -101,7 +101,7 @@ public class AuthClientTest {
   @Test(dependsOnMethods = "testRoleAdd", groups = "role", priority = 1)
   public void testRoleList() throws ExecutionException, InterruptedException {
     AuthRoleListResponse response = this.authDisabledAuthClient.roleList().get();
-    assertThat(response.getRoles().get(0)).isEqualTo(this.rootRole.toStringUtf8());
+    assertThat(response.getRoles().get(0)).isEqualTo(this.rootRole.toString(UTF_8));
   }
 
 
@@ -136,8 +136,8 @@ public class AuthClientTest {
   @Test(dependsOnMethods = "testUserAdd", groups = "user", priority = 1)
   public void testUserList() throws ExecutionException, InterruptedException {
     List<String> users = this.authDisabledAuthClient.userList().get().getUsers();
-    assertThat(users.get(0)).isEqualTo(this.root.toStringUtf8());
-    assertThat(users.get(1)).isEqualTo(this.user.toStringUtf8());
+    assertThat(users.get(0)).isEqualTo(this.root.toString(UTF_8));
+    assertThat(users.get(1)).isEqualTo(this.user.toString(UTF_8));
   }
 
   /**
@@ -154,11 +154,11 @@ public class AuthClientTest {
   @Test(dependsOnMethods = "testUserGrantRole", groups = "user", priority = 1)
   public void testUserGet() throws ExecutionException, InterruptedException {
     assertThat(this.authDisabledAuthClient.userGet(root).get().getRoles().get(0))
-        .isEqualTo(rootRole.toStringUtf8());
+        .isEqualTo(rootRole.toString(UTF_8));
     assertThat(this.authDisabledAuthClient.userGet(user).get().getRoles().get(0))
-        .isEqualTo(rootRole.toStringUtf8());
+        .isEqualTo(rootRole.toString(UTF_8));
     assertThat(this.authDisabledAuthClient.userGet(user).get().getRoles().get(1))
-        .isEqualTo(userRole.toStringUtf8());
+        .isEqualTo(userRole.toString(UTF_8));
   }
 
   /**

--- a/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/KVTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/internal/impl/KVTest.java
@@ -15,6 +15,7 @@
  */
 package io.etcd.jetcd.internal.impl;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -87,7 +88,7 @@ public class KVTest {
     CompletableFuture<GetResponse> getFeature = kvClient.get(SAMPLE_KEY_2);
     GetResponse response = getFeature.get();
     assertEquals(1, response.getKvs().size());
-    assertEquals(SAMPLE_VALUE_2.toStringUtf8(), response.getKvs().get(0).getValue().toStringUtf8());
+    assertEquals(SAMPLE_VALUE_2.toString(UTF_8), response.getKvs().get(0).getValue().toString(UTF_8));
     assertTrue(!response.isMore());
   }
 
@@ -101,7 +102,7 @@ public class KVTest {
     CompletableFuture<GetResponse> getFeature = kvClient.get(SAMPLE_KEY_3, option);
     GetResponse response = getFeature.get();
     assertEquals(1, response.getKvs().size());
-    assertEquals(SAMPLE_VALUE.toStringUtf8(), response.getKvs().get(0).getValue().toStringUtf8());
+    assertEquals(SAMPLE_VALUE.toString(UTF_8), response.getKvs().get(0).getValue().toString(UTF_8));
   }
 
   @Test
@@ -121,8 +122,8 @@ public class KVTest {
 
     assertEquals(numPrefix, response.getKvs().size());
     for (int i = 0; i < numPrefix; i++) {
-      assertEquals(prefix + (numPrefix - i - 1), response.getKvs().get(i).getKey().toStringUtf8());
-      assertEquals(String.valueOf(numPrefix - i - 1), response.getKvs().get(i).getValue().toStringUtf8());
+      assertEquals(prefix + (numPrefix - i - 1), response.getKvs().get(i).getKey().toString(UTF_8));
+      assertEquals(String.valueOf(numPrefix - i - 1), response.getKvs().get(i).getValue().toString(UTF_8));
     }
   }
 
@@ -195,7 +196,7 @@ public class KVTest {
     // get the value
     GetResponse getResp = kvClient.get(sampleKey).get();
     assertEquals(1, getResp.getKvs().size());
-    assertEquals(putValue.toStringUtf8(), getResp.getKvs().get(0).getValue().toStringUtf8());
+    assertEquals(putValue.toString(UTF_8), getResp.getKvs().get(0).getValue().toString(UTF_8));
   }
 
   @Test
@@ -218,11 +219,11 @@ public class KVTest {
 
     GetResponse getResp = kvClient.get(foo).get();
     assertEquals(1, getResp.getKvs().size());
-    assertEquals(bar.toStringUtf8(), getResp.getKvs().get(0).getValue().toStringUtf8());
+    assertEquals(bar.toString(UTF_8), getResp.getKvs().get(0).getValue().toString(UTF_8));
 
     GetResponse getResp2 = kvClient.get(abc).get();
     assertEquals(1, getResp2.getKvs().size());
-    assertEquals(oneTwoThree.toStringUtf8(), getResp2.getKvs().get(0).getValue().toStringUtf8());
+    assertEquals(oneTwoThree.toString(UTF_8), getResp2.getKvs().get(0).getValue().toString(UTF_8));
   }
 
   @AfterClass

--- a/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandGet.java
+++ b/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandGet.java
@@ -16,9 +16,10 @@
 
 package io.etcd.jetcd.examples.jetcdctl;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.data.ByteSequence;
 import io.etcd.jetcd.kv.GetResponse;
@@ -40,7 +41,7 @@ class CommandGet {
   // get executes the "get" command.
   void get(Client client) throws Exception {
     GetResponse getResponse = client.getKVClient().get(
-        ByteSequence.from(key, Charsets.UTF_8),
+        ByteSequence.from(key, UTF_8),
         GetOption.newBuilder().withRevision(rev).build()
     ).get();
     if (getResponse.getKvs().isEmpty()) {
@@ -48,6 +49,6 @@ class CommandGet {
       return;
     }
     LOGGER.info(key);
-    LOGGER.info(getResponse.getKvs().get(0).getValue().toStringUtf8());
+    LOGGER.info(getResponse.getKvs().get(0).getValue().toString(UTF_8));
   }
 }

--- a/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandWatch.java
+++ b/jetcd-examples/jetcd-simple-ctl/src/main/java/io/etcd/jetcd/examples/jetcdctl/CommandWatch.java
@@ -16,6 +16,8 @@
 
 package io.etcd.jetcd.examples.jetcdctl;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Charsets;
@@ -52,8 +54,8 @@ class CommandWatch {
         WatchResponse response = watcher.listen();
         for (WatchEvent event : response.getEvents()) {
           LOGGER.info(event.getEventType().toString());
-          LOGGER.info(event.getKeyValue().getKey().toStringUtf8());
-          LOGGER.info(event.getKeyValue().getValue().toStringUtf8());
+          LOGGER.info(event.getKeyValue().getKey().toString(UTF_8));
+          LOGGER.info(event.getKeyValue().getValue().toString(UTF_8));
         }
       }
 

--- a/jetcd-examples/jetcd-watch-example/src/main/java/io/etcd/jetcd/examples/watch/Main.java
+++ b/jetcd-examples/jetcd-watch-example/src/main/java/io/etcd/jetcd/examples/watch/Main.java
@@ -16,9 +16,10 @@
 
 package io.etcd.jetcd.examples.watch;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import com.google.common.base.Charsets;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.data.ByteSequence;
@@ -43,7 +44,7 @@ public class Main {
 
     try (Client client = Client.builder().endpoints(cmd.endpoints).build();
          Watch watch = client.getWatchClient();
-         Watch.Watcher watcher = watch.watch(ByteSequence.from(cmd.key, Charsets.UTF_8))) {
+         Watch.Watcher watcher = watch.watch(ByteSequence.from(cmd.key, UTF_8))) {
       for (int i = 0; i < cmd.maxEvents; i++) {
         LOGGER.info("Watching for key={}", cmd.key);
         WatchResponse response = watcher.listen();
@@ -52,10 +53,10 @@ public class Main {
           LOGGER.info("type={}, key={}, value={}",
               event.getEventType(),
               Optional.ofNullable(event.getKeyValue().getKey())
-                  .map(ByteSequence::toStringUtf8)
+                  .map(bs -> bs.toString(UTF_8))
                   .orElse(""),
               Optional.ofNullable(event.getKeyValue().getValue())
-                  .map(ByteSequence::toStringUtf8)
+                  .map(bs -> bs.toString(UTF_8))
                   .orElse("")
           );
         }


### PR DESCRIPTION
this includes #363 just to make my life easier (and because GitHub PRs are not like Gerrit); the diff will be much smaller and only show the changes in the last commit once the dependency is merged; in the mean time look at only 3d47cc9865fc2a4a8b248942f6c00c1607ad7813 instead of the Files Changed tab.