### PR TITLE
change Pax Exam IT test to not require a features.xml system property

### DIFF
--- a/jetcd-osgi/jetcd-karaf/pom.xml
+++ b/jetcd-osgi/jetcd-karaf/pom.xml
@@ -177,11 +177,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <features.xml>${project.build.directory}/classes/features.xml</features.xml>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
 
         </plugins>

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/TestSupport.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/TestSupport.java
@@ -23,13 +23,10 @@ import java.net.URL;
 import org.ops4j.pax.exam.ConfigurationManager;
 
 public class TestSupport {
-  private static final String FEATURES_XML = "features.xml";
+  private static final String FEATURES_XML = "/features.xml";
 
   protected File getFeaturesFile() {
-    String featuresXml = System.getProperty(FEATURES_XML);
-    assertThat(featuresXml).isNotNull();
-
-    File featuresFile = new File(featuresXml);
+    File featuresFile = getConfigFile(FEATURES_XML);
     assertThat(featuresFile).exists();
 
     return featuresFile;


### PR DESCRIPTION
This just make it easier to run ClientServiceTest in-IDE instead of on
the mvn CLI, without having to remember to manually set this in the
test's launch config: -Dfeatures.xml=target/classes/features.xml