### PR TITLE
fix jetcd-all which was broken under OSGi (#382)

### DIFF
--- a/jetcd-all/pom.xml
+++ b/jetcd-all/pom.xml
@@ -127,6 +127,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.slf4j;version="[1.7,2)",
+                            javax.security.cert,
                             javax.net.ssl;resolution:=optional
                         </Import-Package>
                     </instructions>

--- a/jetcd-launcher/pom.xml
+++ b/jetcd-launcher/pom.xml
@@ -28,7 +28,6 @@
     </parent>
 
     <artifactId>jetcd-launcher</artifactId>
-    <packaging>bundle</packaging>
 
     <properties>
         <checkstyle.config.location>${basedir}/../etc/checkstyle.xml</checkstyle.config.location>
@@ -63,17 +62,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>etcd :: ${project.artifactId}</Bundle-Name>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jetcd-osgi/jetcd-karaf/pom.xml
+++ b/jetcd-osgi/jetcd-karaf/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jetcd-launcher</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/PaxExamWrapperTest.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/PaxExamWrapperTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.jetcd.osgi;
+
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.notification.Failure;
+
+/**
+ * Pax Exam test wrapper which starts (and stops) an etcd test server via
+ * launcher. We need to do this because jetcd-launcher uses Testcontainers,
+ * which cannot run inside OSGi (due to the use of TCL loadClass(String) in
+ * DockerClientProviderStrategy). And even if we were to use the launcher only
+ * in the config() method (which "is executed before the OSGi container is
+ * launched, so it does run in plain Java"), the Pax Exam probe still needs to
+ * load the entire test class and all of its references (launcher with
+ * Testcontainers) into OSGi, which is a PITA. There is also no easy way to stop
+ * the testcontainer after. It is therefore simplest to just launch the etcd
+ * server before getting Pax Exam's world, like this does.
+ *
+ * @author Michael Vorburger.ch
+ */
+public class PaxExamWrapperTest {
+
+    private static final String ETCD_ENDPOINT_SYSTEM_PROPERTY_NAME = "etcd.endpoint";
+
+    @Rule
+    public final EtcdClusterResource etcd = new EtcdClusterResource("karaf");
+
+    @Test
+    public void testClientServiceChecks() throws Throwable {
+        String endpoint = etcd.cluster().getClientEndpoints().get(0);
+        System.setProperty(ETCD_ENDPOINT_SYSTEM_PROPERTY_NAME, endpoint);
+
+        Optional<Failure> failure = JUnitCore.runClasses(ClientServiceChecks.class).getFailures().stream().findFirst();
+        if (failure.isPresent()) {
+            throw failure.get().getException();
+        }
+    }
+
+    static String getClientEndpoints() {
+        return System.getProperty(ETCD_ENDPOINT_SYSTEM_PROPERTY_NAME);
+    }
+}

--- a/jetcd-osgi/pom.xml
+++ b/jetcd-osgi/pom.xml
@@ -34,7 +34,5 @@
         <module>jetcd-osgi</module>
         <module>jetcd-karaf</module>
     </modules>
-
-
 </project>
 


### PR DESCRIPTION
This fixes #382. It builds on top of and uses #386. 

Read commit message and JavaDoc in PaxExamWrapperTest for further details.