### PR TITLE
make Apache Commons IO a scope test dependency of jetcd-core

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -126,6 +126,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
so that it does not get included in the (fat) jetcd-all, without shading, which is bad.  Stumbled upon this while looking into jetcd-all for #393 (but this DOES NOT fix that issue).