### PR TITLE
add startsWith() to ByteSequence

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/data/ByteSequence.java
@@ -31,6 +31,12 @@ public final class ByteSequence {
     this.hashVal = byteString.hashCode();
   }
 
+  public boolean startsWith(ByteSequence prefix) {
+    ByteString baseByteString = this.getByteString();
+    ByteString prefixByteString = prefix.getByteString();
+    return baseByteString.startsWith(prefixByteString);
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -47,13 +53,13 @@ public final class ByteSequence {
     }
   }
 
-  public ByteString getByteString() {
-    return this.byteString;
-  }
-
   @Override
   public int hashCode() {
     return hashVal;
+  }
+
+  public ByteString getByteString() {
+    return this.byteString;
   }
 
   public String toString(Charset charset) {


### PR DESCRIPTION
related to https://github.com/etcd-io/jetcd/issues/393; I implemented a startsWith() for ByteSequence in external code, via getByteString(), and ran into this issue #393.  I could also just have used getBytes() to
implement a startsWith() for ByteSequence, but that would be less performant.

The hashCode() method was moved just to that it is right after equals, which is customary.