### PR TITLE
jetcd-all must Export-Package shaded protobuf

### DIFF
--- a/jetcd-all/pom.xml
+++ b/jetcd-all/pom.xml
@@ -109,6 +109,7 @@
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>etcd :: ${project.artifactId}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <!-- The (shaded) protobuf has to also be exported because it's part of the public API surface of ByteSequence's getByteString() method; see https://github.com/etcd-io/jetcd/issues/393 -->
                         <Export-Package>
                             io.etcd.jetcd.common.exception,
                             io.etcd.jetcd.resolver,
@@ -123,7 +124,8 @@
                             io.etcd.jetcd.maintenance,
                             io.etcd.jetcd.op,
                             io.etcd.jetcd.options,
-                            io.etcd.jetcd.watch
+                            io.etcd.jetcd.watch,
+                            io.etcd.jetcd.shaded.com.google.protobuf
                         </Export-Package>
                         <Import-Package>
                             org.slf4j;version="[1.7,2)",

--- a/jetcd-osgi/jetcd-karaf/pom.xml
+++ b/jetcd-osgi/jetcd-karaf/pom.xml
@@ -51,7 +51,13 @@
         <!-- jetcd -->
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jetcd-osgi</artifactId>
+            <artifactId>jetcd-all</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>*</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
for ByteSequence.getByteString() to work under OSGi

and non-regression test must use shaded instead of normal protobuf

see https://github.com/etcd-io/jetcd/issues/393