### PR TITLE
jetcd-core: renames compareBuiler to compareBuilder

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
@@ -40,16 +40,16 @@ public class Cmp {
   }
 
   Compare toCompare() {
-    Compare.Builder compareBuiler = Compare.newBuilder().setKey(this.key);
+    Compare.Builder compareBuilder = Compare.newBuilder().setKey(this.key);
     switch (this.op) {
       case EQUAL:
-        compareBuiler.setResult(Compare.CompareResult.EQUAL);
+        compareBuilder.setResult(Compare.CompareResult.EQUAL);
         break;
       case GREATER:
-        compareBuiler.setResult(Compare.CompareResult.GREATER);
+        compareBuilder.setResult(Compare.CompareResult.GREATER);
         break;
       case LESS:
-        compareBuiler.setResult(Compare.CompareResult.LESS);
+        compareBuilder.setResult(Compare.CompareResult.LESS);
         break;
       default:
         throw new IllegalArgumentException("Unexpected compare type (" + this.op + ")");
@@ -58,24 +58,24 @@ public class Cmp {
     Compare.CompareTarget target = this.target.getTarget();
     Object value = this.target.getTargetValue();
 
-    compareBuiler.setTarget(target);
+    compareBuilder.setTarget(target);
     switch (target) {
       case VERSION:
-        compareBuiler.setVersion((Long) value);
+        compareBuilder.setVersion((Long) value);
         break;
       case VALUE:
-        compareBuiler.setValue((ByteString) value);
+        compareBuilder.setValue((ByteString) value);
         break;
       case MOD:
-        compareBuiler.setModRevision((Long) value);
+        compareBuilder.setModRevision((Long) value);
         break;
       case CREATE:
-        compareBuiler.setCreateRevision((Long) value);
+        compareBuilder.setCreateRevision((Long) value);
         break;
       default:
         throw new IllegalArgumentException("Unexpected target type (" + target + ")");
     }
 
-    return compareBuiler.build();
+    return compareBuilder.build();
   }
 }


### PR DESCRIPTION
A typo existing is the file that, while not critical, can lead to confusion

Fixes #420