### PR TITLE
add findbugs:annotations for javax.annotation.Nonnull

### DIFF
--- a/jetcd-launcher/pom.xml
+++ b/jetcd-launcher/pom.xml
@@ -36,6 +36,19 @@
 
     <dependencies>
         <dependency>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+          <version>3.0.0</version>
+          <scope>provided</scope>
+          <optional>true</optional>
+          <exclusions>
+            <exclusion>
+              <artifactId>jcip-annotations</artifactId>
+              <groupId>net.jcip</groupId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
We are currently inheriting this from an indirect transitive dependency
from testcontainers 1.9.1, but in 1.10.0 they dropped this; in order to
bump testcontainers from 1.9.1 to 1.10.0, we need to add this as a
direct dependency.

The exclusion is because jcip contains duplicates.  The <scope>provided
and <optional>true is because these annotation are only for static
analysis during build time, not required at runtime.

Testcontainers 1.9.1 actually used the older findbugs:jsr305
and not findbugs:annotations which is newer.