### PR TITLE
Fix compaction exception and save revision on progress notify

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -195,7 +195,9 @@ final class WatchImpl implements Watch {
         String reason = response.getCancelReason();
         Throwable error;
 
-        if (Strings.isNullOrEmpty(reason)) {
+        if (response.getCompactRevision() != 0) {
+          error = newCompactedException(response.getCompactRevision());
+        } else if (Strings.isNullOrEmpty(reason)) {
           error = newEtcdException(
             ErrorCode.OUT_OF_RANGE,
             "etcdserver: mvcc: required revision is a future revision"
@@ -208,13 +210,6 @@ final class WatchImpl implements Watch {
         }
 
         listener.onError(error);
-      } else if (response.getCompactRevision() != 0) {
-        
-        //
-        // Compact
-        //
-
-        listener.onError(newCompactedException(response.getCompactRevision()));
       } else if (response.getEventsCount() == 0 && option.isProgressNotify()) {
         
         //
@@ -232,7 +227,6 @@ final class WatchImpl implements Watch {
         // For more info:
         //   https://coreos.com/etcd/docs/latest/learning/api.html#watch-streams
         //
-
         listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));
       } else if (response.getEventsCount() > 0) {
         listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));

--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -228,6 +228,7 @@ final class WatchImpl implements Watch {
         //   https://coreos.com/etcd/docs/latest/learning/api.html#watch-streams
         //
         listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));
+        revision = response.getHeader().getRevision();
       } else if (response.getEventsCount() > 0) {
         listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));
         revision = response.getEvents(response.getEventsCount() - 1).getKv().getModRevision() + 1;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
@@ -305,7 +305,7 @@ public class WatchUnitTest {
       WatchResponse createdResponse = createWatchResponse(0);
       responseObserverRef.get().onNext(createdResponse);
 
-      WatchResponse compactedResponse = WatchResponse.newBuilder().setCompactRevision(2).build();
+      WatchResponse compactedResponse = WatchResponse.newBuilder().setCanceled(true).setCompactRevision(2).build();
       responseObserverRef.get().onNext(compactedResponse);
 
       latch.await(4, TimeUnit.SECONDS);


### PR DESCRIPTION
Hi we recently enabled compaction in our etcd cluster and run into some issues.

From our tests the compactrevision != 0 case happens only if the canceled flag is also set.
I wrote a test to confirm that behavior (although i don't know if the other one is possible).

The second thing i changed is that the revision is saved on progress notify. This was in the last implementation of the watch and got removed, i am not sure why. (The go implementation also seems to save nextrev if it is a progress notifiy message).

Please feel free to comment :)

Thanks in advance,

David
