### PR TITLE
jetcd-core(watch): fix resuming watch after server disconnection

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -250,9 +250,10 @@ final class WatchImpl implements Watch {
 
       if (Util.isHaltError(status) || Util.isNoLeaderError(status)) {
         listener.onError(toEtcdException(status));
-        stream.onCompleted();
-        stream = null;
       }
+
+      stream.onCompleted();
+      stream = null;
 
       // resume with a delay; avoiding immediate retry on a long connection downtime.
       Util.addOnFailureLoggingCallback(


### PR DESCRIPTION
Hi,
This PR should address stale watchers due to etcd node restarts. 

The watcher stream was not completed after receiving UNAVAILABLE or INTERNAL errors from the etcd cluster making the listener attached to it stale. The reason is that the subsequent call to WatcherImpl::resume does nothing unless the stream is set to null. This patchset completes the stream and sets it to null regardless of the error, in this way the call to resume will always recreate a new stream.

Feel free to comment and let me know if my assumptions are incorrect.
