### PR TITLE
jetcd-core(watch): add test for watch resume after server disconnection

### DIFF
--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchResumeTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchResumeTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.etcd.jetcd;
+
+import io.etcd.jetcd.Watch.Watcher;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
+import io.etcd.jetcd.watch.WatchEvent.EventType;
+import io.etcd.jetcd.watch.WatchResponse;
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * watch resume test case.
+ */
+public class WatchResumeTest {
+  @ClassRule
+  public static final EtcdClusterResource clusterResource = new EtcdClusterResource("watch_resume", 3, false, true);
+
+  private static Client client;
+  private static Watch watchClient;
+  private static KV kvClient;
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(30);
+
+  @BeforeClass
+  public static void setUp() {
+    client = Client.builder().endpoints(clusterResource.cluster().getClientEndpoints()).build();
+    watchClient = client.getWatchClient();
+    kvClient = client.getKVClient();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    client.close();
+  }
+
+  @Test
+  public void testWatchOnPut() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    ByteSequence key = TestUtil.randomByteSequence();
+    ByteSequence value = TestUtil.randomByteSequence();
+    AtomicReference<WatchResponse> ref = new AtomicReference<>();
+
+    Watcher watcher = null;
+
+    try {
+      watcher = watchClient.watch(key, response -> {
+        ref.set(response);
+        latch.countDown();
+      });
+
+      clusterResource.cluster().restart();
+
+      kvClient.put(key, value).get(1, TimeUnit.SECONDS);
+      latch.await(4, TimeUnit.SECONDS);
+
+      assertThat(ref.get()).isNotNull();
+      assertThat(ref.get().getEvents().size()).isEqualTo(1);
+      assertThat(ref.get().getEvents().get(0).getEventType()).isEqualTo(EventType.PUT);
+      assertThat(ref.get().getEvents().get(0).getKeyValue().getKey()).isEqualTo(key);
+    } finally {
+      IOUtils.closeQuietly(watcher);
+    }
+  }
+}

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdCluster.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdCluster.java
@@ -24,6 +24,8 @@ public interface EtcdCluster extends AutoCloseable {
 
   void start();
 
+  void restart();
+
   @Override
   void close();
 

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit/EtcdClusterResource.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit/EtcdClusterResource.java
@@ -32,7 +32,11 @@ public class EtcdClusterResource extends ExternalResource {
   }
 
   public EtcdClusterResource(String clusterName, int nodes, boolean ssl) {
-    this.cluster = EtcdClusterFactory.buildCluster(clusterName, nodes, ssl);
+    this(clusterName, nodes, ssl, false);
+  }
+
+  public EtcdClusterResource(String clusterName, int nodes, boolean ssl, boolean restartable) {
+    this.cluster = EtcdClusterFactory.buildCluster(clusterName, nodes, ssl, restartable);
   }
 
   public EtcdCluster cluster() {


### PR DESCRIPTION
Hi,
as requested in #439 I wrote a test for [WatcherImpl.resume()](https://github.com/fdimuccio/jetcd/blob/bff48ca85ffcd87f6ad93432e0e888b7a3592606/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java#L122). The test is a bit tricky and I couldn't find a better way than implementing a rolling restart in the EtcdCluster. In order to do that I had to persist the etcd data in a volume outside the container (data is cleaned once the test ends). One good thing is that this behavior is completely optional and must be explicitly enabled.
