### PR TITLE
chore(build): exclude annotation JARs from jetcd-all "fat" JAR

### DIFF
--- a/jetcd-all/pom.xml
+++ b/jetcd-all/pom.xml
@@ -32,10 +32,38 @@
         <dependency>
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-common</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-annotations</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-compat-qual</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.j2objc</groupId>
+                <artifactId>j2objc-annotations</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-compat-qual</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.etcd</groupId>


### PR DESCRIPTION
because they are not needed at run-time and only bloat the "fat" JAR

and can cause conflicts when building other projects depending on this:

[INFO] --- duplicate-finder-maven-plugin:1.3.0:check(find-duplicate-classpath-entries) @ jetcd ---
[WARNING] Found duplicate and different classes in [io.etcd:jetcd-all:0.3.0-SNAPSHOT, org.checkerframework:checker-compat-qual:2.5.3]:
[WARNING]   org.checkerframework.checker.nullness.compatqual.KeyForDecl
[WARNING]   org.checkerframework.checker.nullness.compatqual.KeyForType
[WARNING]   org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl
[WARNING]   org.checkerframework.checker.nullness.compatqual.MonotonicNonNullType
[WARNING]   org.checkerframework.checker.nullness.compatqual.NonNullDecl
[WARNING]   org.checkerframework.checker.nullness.compatqual.NonNullType
[WARNING]   org.checkerframework.checker.nullness.compatqual.NullableDecl
[WARNING]   org.checkerframework.checker.nullness.compatqual.NullableType
[WARNING]   org.checkerframework.checker.nullness.compatqual.PolyNullDecl
[WARNING]   org.checkerframework.checker.nullness.compatqual.PolyNullType
[WARNING] Found duplicate and different classes in [io.etcd:jetcd-all:0.3.0-SNAPSHOT, org.codehaus.mojo:animal-sniffer-annotations:1.14]:
[WARNING]   org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
[WARNING] Found duplicate classes/resources in test classpath.