### PR TITLE
add tests to illustrate how to use EtcdClusterFactory

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -130,6 +130,11 @@
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jetcd-core/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterUsingTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterUsingTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.etcd.jetcd.launcher.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+
+/**
+ * Simple test illustrating how to use the {@link EtcdClusterFactory} with the jetcd client.
+ *
+ * <p>Tests typically would use the EtcdClusterResource JUnit rule instead of the EtcdClusterFactory direct.
+ *
+ * @author Michael Vorburger.ch
+ */
+public class EtcdClusterUsingTest {
+
+    @Test
+    public void testUseEtcd() throws Exception {
+        try (EtcdCluster etcd = EtcdClusterFactory.buildCluster(getClass().getSimpleName(), 3, false, false)) {
+            etcd.start();
+            try (Client client = Client.builder().endpoints(etcd.getClientEndpoints()).build()) {
+                try (KV kvClient = client.getKVClient()) {
+
+                    ByteSequence key = ByteSequence.from("test_key", UTF_8);
+                    ByteSequence value = ByteSequence.from("test_value", UTF_8);
+                    kvClient.put(key, value).get();
+
+                    CompletableFuture<GetResponse> getFuture = kvClient.get(key);
+                    GetResponse response = getFuture.get();
+                    List<KeyValue> values = response.getKvs();
+                    assertThat(values).hasSize(1);
+                    KeyValue value1 = values.get(0);
+                    assertThat(value1.getValue()).isEqualTo(value);
+                    assertThat(value1.getKey()).isEqualTo(key);
+                }
+            }
+        }
+    }
+}

--- a/jetcd-launcher/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterStartTest.java
+++ b/jetcd-launcher/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterStartTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.jetcd.launcher.test;
+
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import org.junit.Test;
+
+/**
+ * Tests (just) starting the {@link EtcdClusterFactory}.
+ *
+ * <p>See the EtcdClusterUsingTest in the jetcd-core artifact for more.
+ *
+ * @author Michael Vorburger.ch
+ */
+public class EtcdClusterStartTest {
+
+    @Test
+    public void testStartEtcd() throws Exception {
+        try (EtcdCluster etcd = EtcdClusterFactory.buildCluster(getClass().getSimpleName(), 3, false, false)) {
+            etcd.start();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.google.truth</groupId>
+                <artifactId>truth</artifactId>
+                <scope>test</scope>
+                <version>0.42</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
@@ -432,7 +438,7 @@
                             <arg>-Xep:UnnecessaryStaticImport:ERROR</arg>
                             <arg>-Xep:UseBinds:ERROR</arg>
                             <arg>-Xep:WildcardImport:ERROR</arg>
-                            <!-- FutureReturnValueIgnored is better (stronger) than error-prone's own (and FindBug's) @CheckReturnValue annotation, 
+                            <!-- FutureReturnValueIgnored is better (stronger) than error-prone's own (and FindBug's) @CheckReturnValue annotation,
                                  as it checks that ANY return Future are checked, not just those from methods annotated @CheckReturnValue -->
                             <arg>-Xep:FutureReturnValueIgnored:ERROR</arg>
                             <arg>-Xep:IntLongMath:ERROR</arg>


### PR DESCRIPTION
The EtcdClusterUsingTest unfortunately cannot be put into
jetcd-launcher/src/test/java, because it requires io.etcd.jetcd (our
client, which is in core), so we put that one in core but keep at least
the more basic EtcdClusterStartTest into launcher.