### PR TITLE
Support namespace in jetcd

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -23,6 +23,9 @@ import java.nio.charset.Charset;
  * Etcd binary bytes, easy to convert between byte[], String and ByteString.
  */
 public final class ByteSequence {
+  public static final ByteSequence EMPTY = new ByteSequence(ByteString.EMPTY);
+  public static final ByteSequence NAMESPACE_DELIMITER = ByteSequence.from(new byte[] {'/'});
+
   private final int hashVal;
   private final ByteString byteString;
 
@@ -68,6 +71,14 @@ public final class ByteSequence {
 
   public byte[] getBytes() {
     return byteString.toByteArray();
+  }
+
+  public boolean isEmpty() {
+    return byteString.isEmpty();
+  }
+
+  public int size() {
+    return byteString.size();
   }
 
   /**

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -57,6 +57,7 @@ public final class ClientBuilder implements Cloneable {
   private Integer maxInboundMessageSize;
   private Map<Metadata.Key, Object> headers;
   private List<ClientInterceptor> interceptors;
+  private ByteSequence namespace = ByteSequence.EMPTY;
 
   ClientBuilder() {
   }
@@ -139,6 +140,35 @@ public final class ClientBuilder implements Cloneable {
   public ClientBuilder password(ByteSequence password) {
     checkNotNull(password, "password can't be null");
     this.password = password;
+    return this;
+  }
+
+  public ByteSequence namespace() {
+    return namespace;
+  }
+
+  /**
+   * config the namespace of keys used in {@code KV}, {@code Txn}, {@code Lock} and {@code Watch}.
+   * "/" will be treated as no namespace.
+   *
+   * @param namespace the namespace of each key used
+   * @return this builder
+   * @throws NullPointerException if namespace is <code>null</code>
+   */
+  public ClientBuilder namespace(ByteSequence namespace) {
+    checkNotNull(namespace);
+    if (namespace.getByteString().isEmpty()) {
+      this.namespace = ByteSequence.EMPTY;
+    } else if (namespace.size() == 1 && namespace.getByteString().equals(ByteSequence.NAMESPACE_DELIMITER)) {
+      // treat "/" as no namespace
+      this.namespace = ByteSequence.EMPTY;
+    } else if (namespace.getByteString().byteAt(namespace.getByteString().size() - 1) == '/') {
+      this.namespace = namespace;
+    } else {
+      // make sure the namespace ends with '/'
+      this.namespace = ByteSequence.from(namespace.getByteString().concat(
+          ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    }
     return this;
   }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -159,7 +159,8 @@ public final class ClientBuilder implements Cloneable {
     checkNotNull(namespace);
     if (namespace.getByteString().isEmpty()) {
       this.namespace = ByteSequence.EMPTY;
-    } else if (namespace.size() == 1 && namespace.getByteString().equals(ByteSequence.NAMESPACE_DELIMITER)) {
+    } else if (namespace.size() == 1
+        && namespace.getByteString().equals(ByteSequence.NAMESPACE_DELIMITER.getByteString())) {
       // treat "/" as no namespace
       this.namespace = ByteSequence.EMPTY;
     } else if (namespace.getByteString().byteAt(namespace.getByteString().size() - 1) == '/') {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -120,6 +120,9 @@ final class ClientConnectionManager {
     }
   }
 
+  ByteSequence getNamespace() {
+    return builder.namespace();
+  }
 
   ExecutorService getExecutorService() {
     return executorService;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
@@ -102,8 +102,7 @@ final class KVImpl implements KV {
         .setSortTarget(toRangeRequestSortTarget(option.getSortField()));
 
     option.getEndKey()
-      .map(endKey -> Util.prefixNamespaceToRangeEnd(key.getByteString(),
-          endKey.getByteString(), namespace))
+      .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
       .ifPresent(builder::setRangeEnd);
 
     RangeRequest request = builder.build();
@@ -131,8 +130,7 @@ final class KVImpl implements KV {
         .setPrevKv(option.isPrevKV());
 
     option.getEndKey()
-      .map(endKey -> Util.prefixNamespaceToRangeEnd(key.getByteString(),
-          endKey.getByteString(), namespace))
+      .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
       .ifPresent(builder::setRangeEnd);
 
     DeleteRangeRequest request = builder.build();

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
@@ -21,18 +21,22 @@ package io.etcd.jetcd;
  */
 public class KeyValue {
 
-  private io.etcd.jetcd.api.KeyValue kv;
+  private final io.etcd.jetcd.api.KeyValue kv;
+  private final ByteSequence unprefixedKey;
+  private final ByteSequence value;
 
-  public KeyValue(io.etcd.jetcd.api.KeyValue kv) {
+  public KeyValue(io.etcd.jetcd.api.KeyValue kv, ByteSequence namespace) {
     this.kv = kv;
+    this.unprefixedKey = ByteSequence.from(Util.unprefixNamespace(kv.getKey(), namespace));
+    this.value = ByteSequence.from(kv.getValue());
   }
 
   public ByteSequence getKey() {
-    return ByteSequence.from(kv.getKey());
+    return unprefixedKey;
   }
 
   public ByteSequence getValue() {
-    return ByteSequence.from(kv.getValue());
+    return value;
   }
 
   public long getCreateRevision() {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
@@ -27,7 +27,8 @@ public class KeyValue {
 
   public KeyValue(io.etcd.jetcd.api.KeyValue kv, ByteSequence namespace) {
     this.kv = kv;
-    this.unprefixedKey = ByteSequence.from(Util.unprefixNamespace(kv.getKey(), namespace));
+    this.unprefixedKey = ByteSequence.from(kv.getKey().isEmpty() ? kv.getKey()
+        : Util.unprefixNamespace(kv.getKey(), namespace));
     this.value = ByteSequence.from(kv.getValue());
   }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
@@ -234,18 +234,17 @@ public final class Util {
     return namespace.isEmpty() ? key : namespace.getByteString().concat(key);
   }
 
-  public static ByteString prefixNamespaceToRangeEnd(
-      ByteString key, ByteString end, ByteSequence namespace) {
+  public static ByteString prefixNamespaceToRangeEnd(ByteString end, ByteSequence namespace) {
     if (namespace.isEmpty()) {
       return end;
     }
 
     if (end.size() == 1 && end.toByteArray()[0] == 0) {
       // range end is '\0', calculate the prefixed range end by (key + 1)
-      byte[] prefixedEndArray = key.toByteArray();
+      byte[] prefixedEndArray = namespace.getByteString().toByteArray();
       boolean ok = false;
       for (int i = (prefixedEndArray.length - 1); i >= 0; i--) {
-        prefixedEndArray[i]++;
+        prefixedEndArray[i] = (byte) (prefixedEndArray[i] + 1);
         if (prefixedEndArray[i] != 0) {
           ok = true;
           break;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -137,8 +137,7 @@ final class WatchImpl implements Watch {
             .setStartRevision(this.revision);
 
         option.getEndKey()
-            .map(endKey -> Util.prefixNamespaceToRangeEnd(this.key.getByteString(),
-                endKey.getByteString(), namespace))
+            .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
             .ifPresent(builder::setRangeEnd);
 
         if (option.isNoDelete()) {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.api.DeleteRangeResponse;
 import java.util.List;
@@ -24,10 +25,13 @@ import java.util.stream.Collectors;
 
 public class DeleteResponse extends AbstractResponse<DeleteRangeResponse> {
 
+  private final ByteSequence namespace;
+
   private List<KeyValue> prevKvs;
 
-  public DeleteResponse(DeleteRangeResponse deleteRangeResponse) {
+  public DeleteResponse(DeleteRangeResponse deleteRangeResponse, ByteSequence namespace) {
     super(deleteRangeResponse, deleteRangeResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
@@ -43,7 +47,7 @@ public class DeleteResponse extends AbstractResponse<DeleteRangeResponse> {
   public synchronized List<KeyValue> getPrevKvs() {
     if (prevKvs == null) {
       prevKvs = getResponse().getPrevKvsList().stream()
-          .map(KeyValue::new)
+          .map(kv -> new KeyValue(kv, namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.api.RangeResponse;
 import java.util.List;
@@ -24,10 +25,13 @@ import java.util.stream.Collectors;
 
 public class GetResponse extends AbstractResponse<RangeResponse> {
 
+  private final ByteSequence namespace;
+
   private List<KeyValue> kvs;
 
-  public GetResponse(RangeResponse rangeResponse) {
+  public GetResponse(RangeResponse rangeResponse, ByteSequence namespace) {
     super(rangeResponse, rangeResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
@@ -36,7 +40,7 @@ public class GetResponse extends AbstractResponse<RangeResponse> {
   public synchronized List<KeyValue> getKvs() {
     if (kvs == null) {
       kvs = getResponse().getKvsList().stream()
-          .map(KeyValue::new)
+          .map(kv -> new KeyValue(kv, namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
@@ -17,19 +17,23 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 
 public class PutResponse extends AbstractResponse<io.etcd.jetcd.api.PutResponse> {
 
-  public PutResponse(io.etcd.jetcd.api.PutResponse putResponse) {
+  private final ByteSequence namespace;
+
+  public PutResponse(io.etcd.jetcd.api.PutResponse putResponse, ByteSequence namespace) {
     super(putResponse, putResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
    * return previous key-value pair.
    */
   public KeyValue getPrevKv() {
-    return new KeyValue(getResponse().getPrevKv());
+    return new KeyValue(getResponse().getPrevKv(), namespace);
   }
 
   public boolean hasPrevKv() {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
@@ -21,7 +21,10 @@ import static io.etcd.jetcd.api.ResponseOp.ResponseCase.RESPONSE_PUT;
 import static io.etcd.jetcd.api.ResponseOp.ResponseCase.RESPONSE_RANGE;
 import static io.etcd.jetcd.api.ResponseOp.ResponseCase.RESPONSE_TXN;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,15 +34,22 @@ import java.util.stream.Collectors;
  */
 public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse> {
 
-  // TODO add txnResponsesRef when nested txn is implemented.
+  private final ByteSequence namespace;
+
   private List<PutResponse> putResponses;
   private List<GetResponse> getResponses;
   private List<DeleteResponse> deleteResponses;
   private List<TxnResponse> txnResponses;
 
 
-  public TxnResponse(io.etcd.jetcd.api.TxnResponse txnResponse) {
+  public TxnResponse(io.etcd.jetcd.api.TxnResponse txnResponse, ByteSequence namespace) {
     super(txnResponse, txnResponse.getHeader());
+    this.namespace = namespace;
+  }
+
+  @VisibleForTesting
+  public TxnResponse(io.etcd.jetcd.api.TxnResponse txnResponse) {
+    this(txnResponse, ByteSequence.EMPTY);
   }
 
   /**
@@ -56,7 +66,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (deleteResponses == null) {
       deleteResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_DELETE_RANGE)
-          .map(responseOp -> new DeleteResponse(responseOp.getResponseDeleteRange()))
+          .map(responseOp -> new DeleteResponse(responseOp.getResponseDeleteRange(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -70,7 +80,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (getResponses == null) {
       getResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_RANGE)
-          .map(responseOp -> new GetResponse(responseOp.getResponseRange()))
+          .map(responseOp -> new GetResponse(responseOp.getResponseRange(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -84,7 +94,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (putResponses == null) {
       putResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_PUT)
-          .map(responseOp -> new PutResponse(responseOp.getResponsePut()))
+          .map(responseOp -> new PutResponse(responseOp.getResponsePut(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -95,7 +105,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (txnResponses == null) {
       txnResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_TXN)
-          .map(responseOp -> new TxnResponse(responseOp.getResponseTxn()))
+          .map(responseOp -> new TxnResponse(responseOp.getResponseTxn(), namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
@@ -18,11 +18,15 @@ package io.etcd.jetcd.lock;
 
 import io.etcd.jetcd.AbstractResponse;
 import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Util;
 
 public class LockResponse extends AbstractResponse<io.etcd.jetcd.api.lock.LockResponse> {
 
-  public LockResponse(io.etcd.jetcd.api.lock.LockResponse response) {
+  private final ByteSequence unprefixedKey;
+
+  public LockResponse(io.etcd.jetcd.api.lock.LockResponse response, ByteSequence namespace) {
     super(response, response.getHeader());
+    this.unprefixedKey = ByteSequence.from(Util.unprefixNamespace(getResponse().getKey(), namespace));
   }
 
   /**
@@ -31,7 +35,7 @@ public class LockResponse extends AbstractResponse<io.etcd.jetcd.api.lock.LockRe
    * undefined behavior.
    */
   public ByteSequence getKey() {
-    return ByteSequence.from(getResponse().getKey());
+    return unprefixedKey;
   }
 
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
@@ -18,10 +18,11 @@ package io.etcd.jetcd.op;
 
 import com.google.protobuf.ByteString;
 import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Util;
 import io.etcd.jetcd.api.Compare;
 
 /**
- * The compare predicate in {@link Txn}.
+ * The compare predicate in {@link io.etcd.jetcd.Txn}.
  */
 public class Cmp {
 
@@ -39,8 +40,9 @@ public class Cmp {
     this.target = target;
   }
 
-  Compare toCompare() {
-    Compare.Builder compareBuilder = Compare.newBuilder().setKey(this.key);
+  Compare toCompare(ByteSequence namespace) {
+    Compare.Builder compareBuilder = Compare.newBuilder().setKey(
+        Util.prefixNamespace(this.key, namespace));
     switch (this.op) {
       case EQUAL:
         compareBuilder.setResult(Compare.CompareResult.EQUAL);

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
@@ -21,6 +21,7 @@ import static io.etcd.jetcd.options.OptionsUtil.toRangeRequestSortTarget;
 
 import com.google.protobuf.ByteString;
 import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Util;
 import io.etcd.jetcd.api.DeleteRangeRequest;
 import io.etcd.jetcd.api.PutRequest;
 import io.etcd.jetcd.api.RangeRequest;
@@ -50,7 +51,7 @@ public abstract class Op {
     this.key = key;
   }
 
-  abstract RequestOp toRequestOp();
+  abstract RequestOp toRequestOp(ByteSequence namespace);
 
   public static PutOp put(ByteSequence key, ByteSequence value, PutOption option) {
     return new PutOp(ByteString.copyFrom(key.getBytes()), ByteString.copyFrom(value.getBytes()),
@@ -80,9 +81,9 @@ public abstract class Op {
       this.option = option;
     }
 
-    RequestOp toRequestOp() {
+    RequestOp toRequestOp(ByteSequence namespace) {
       PutRequest put = PutRequest.newBuilder()
-          .setKey(this.key)
+          .setKey(Util.prefixNamespace(this.key, namespace))
           .setValue(this.value)
           .setLease(this.option.getLeaseId())
           .setPrevKv(this.option.getPrevKV())
@@ -101,9 +102,9 @@ public abstract class Op {
       this.option = option;
     }
 
-    RequestOp toRequestOp() {
+    RequestOp toRequestOp(ByteSequence namespace) {
       RangeRequest.Builder range = RangeRequest.newBuilder()
-          .setKey(this.key)
+          .setKey(Util.prefixNamespace(this.key, namespace))
           .setCountOnly(this.option.isCountOnly())
           .setLimit(this.option.getLimit())
           .setRevision(this.option.getRevision())
@@ -113,7 +114,9 @@ public abstract class Op {
           .setSortTarget(toRangeRequestSortTarget(this.option.getSortField()));
 
       this.option.getEndKey()
-          .ifPresent(endkey -> range.setRangeEnd(ByteString.copyFrom(endkey.getBytes())));
+          .map(endKey -> Util.prefixNamespaceToRangeEnd(this.key,
+              ByteString.copyFrom(endKey.getBytes()), namespace))
+          .ifPresent(range::setRangeEnd);
 
       return RequestOp.newBuilder().setRequestRange(range).build();
     }
@@ -128,14 +131,15 @@ public abstract class Op {
       this.option = option;
     }
 
-    RequestOp toRequestOp() {
+    RequestOp toRequestOp(ByteSequence namespace) {
       DeleteRangeRequest.Builder delete = DeleteRangeRequest.newBuilder()
-          .setKey(this.key)
+          .setKey(Util.prefixNamespace(this.key, namespace))
           .setPrevKv(this.option.isPrevKV());
 
-      if (this.option.getEndKey().isPresent()) {
-        delete.setRangeEnd(ByteString.copyFrom(this.option.getEndKey().get().getBytes()));
-      }
+      this.option.getEndKey()
+          .map(endKey -> Util.prefixNamespaceToRangeEnd(this.key,
+              ByteString.copyFrom(endKey.getBytes()), namespace))
+          .ifPresent(delete::setRangeEnd);
 
       return RequestOp.newBuilder().setRequestDeleteRange(delete).build();
     }
@@ -156,24 +160,24 @@ public abstract class Op {
       this.elseOps = elseOps;
     }
 
-    RequestOp toRequestOp() {
+    RequestOp toRequestOp(ByteSequence namespace) {
       TxnRequest.Builder txn = TxnRequest.newBuilder();
 
       if (cmps != null) {
         for (Cmp cmp : cmps) {
-          txn.addCompare(cmp.toCompare());
+          txn.addCompare(cmp.toCompare(namespace));
         }
       }
 
       if (thenOps != null) {
         for (Op thenOp : thenOps) {
-          txn.addSuccess(thenOp.toRequestOp());
+          txn.addSuccess(thenOp.toRequestOp(namespace));
         }
       }
 
       if (elseOps != null) {
         for (Op elseOp : elseOps) {
-          txn.addFailure(elseOp.toRequestOp());
+          txn.addFailure(elseOp.toRequestOp(namespace));
         }
       }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
@@ -114,7 +114,7 @@ public abstract class Op {
           .setSortTarget(toRangeRequestSortTarget(this.option.getSortField()));
 
       this.option.getEndKey()
-          .map(endKey -> Util.prefixNamespaceToRangeEnd(this.key,
+          .map(endKey -> Util.prefixNamespaceToRangeEnd(
               ByteString.copyFrom(endKey.getBytes()), namespace))
           .ifPresent(range::setRangeEnd);
 
@@ -137,7 +137,7 @@ public abstract class Op {
           .setPrevKv(this.option.isPrevKV());
 
       this.option.getEndKey()
-          .map(endKey -> Util.prefixNamespaceToRangeEnd(this.key,
+          .map(endKey -> Util.prefixNamespaceToRangeEnd(
               ByteString.copyFrom(endKey.getBytes()), namespace))
           .ifPresent(delete::setRangeEnd);
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
@@ -1,0 +1,500 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.etcd.jetcd;
+
+import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+import io.etcd.jetcd.kv.DeleteResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.kv.TxnResponse;
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import io.etcd.jetcd.op.Cmp;
+import io.etcd.jetcd.op.CmpTarget;
+import io.etcd.jetcd.op.Op;
+import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.PutOption;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases focusing on using KVClient and TxnClient with non-empty namespace.
+ */
+public class KVNamespaceTest {
+  private static final ByteSequence END_KEY = ByteSequence.from(new byte[] {0});
+
+  public static final EtcdCluster CLUSTER = EtcdClusterFactory.buildCluster(
+      "etcd-kv-namespace-test", 3 ,false);
+  private KV kvClient;
+  private KV kvClientWithNamespace;
+  private KV kvClientWithNamespace2;
+
+  private static Integer keyIndex = -1;
+
+  @BeforeClass
+  public static void setUp() {
+    CLUSTER.start();
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException {
+    CLUSTER.close();
+  }
+
+  @After
+  public void cleanUpCase() {
+    if (kvClient != null) {
+      kvClient.close();
+      kvClient = null;
+    }
+    if (kvClientWithNamespace != null) {
+      kvClientWithNamespace.close();
+      kvClientWithNamespace = null;
+    }
+    if (kvClientWithNamespace2 != null) {
+      kvClientWithNamespace2.close();
+      kvClientWithNamespace2 = null;
+    }
+  }
+
+  @Test
+  public void testPrefixNamespace() {
+    class TestCase {
+      public ByteSequence namespace;
+      public ByteString key;
+      public ByteString end;
+      public ByteString wKey;
+      public ByteString wEnd;
+
+      public TestCase(ByteSequence namespace, ByteString key, ByteString end,
+          ByteString wKey, ByteString wEnd) {
+        this.namespace = namespace;
+        this.key = key;
+        this.end = end;
+        this.wKey = wKey;
+        this.wEnd = wEnd;
+      }
+    }
+    List<TestCase> testCases = Arrays.asList(
+        // single key
+        new TestCase(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("a".getBytes(Charsets.UTF_8)),
+            null,
+            ByteString.copyFrom("pfx/a".getBytes(Charsets.UTF_8)),
+            null),
+        // range
+        new TestCase(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("def".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx/def".getBytes(Charsets.UTF_8))),
+        // one-sided range
+        new TestCase(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom(new byte[] {0}),
+            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx0".getBytes(Charsets.UTF_8))),
+        // one-sided range, end of key space
+        new TestCase(
+            ByteSequence.from(new byte[] {(byte) 0xff, (byte) 0xff}),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom(new byte[] {0}),
+            ByteString.copyFrom(new byte[] {(byte) 0xff, (byte) 0xff, 'a', 'b', 'c'}),
+            ByteString.copyFrom(new byte[] {0})
+        )
+    );
+    testCases.forEach(testCase -> {
+      ByteString wKey = Util.prefixNamespace(testCase.key, testCase.namespace);
+      assertEquals(testCase.wKey, wKey);
+      if (testCase.end != null) {
+        ByteString wEnd = Util.prefixNamespaceToRangeEnd(testCase.end, testCase.namespace);
+        assertEquals(testCase.wEnd, wEnd);
+      }
+    });
+  }
+
+  @Test
+  public void testKV() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+    // kvClient with another namespace used to test keyed segregation based on namespace
+    ByteSequence namespace2 = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace2 = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace2).build().getKVClient();
+
+    // test single key
+    {
+      ByteSequence key = getNonexistentKey();
+      ByteSequence wKey = ByteSequence.from(namespace.getByteString().concat(key.getByteString()));
+      ByteSequence value = null;
+      ByteSequence prevValue = null;
+
+      assertNonexistentKey(kvClient, wKey);
+      assertNonexistentKey(kvClientWithNamespace, key);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 1. kvClient with namespace should not see keys without such prefix
+      value = TestUtil.randomByteSequence();
+      assertEquals(false, putKVWithAssertion(kvClient, key, value, null));
+      assertExistentKey(kvClient, key, value);
+      assertNonexistentKey(kvClientWithNamespace, key);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+      deleteKVWithAssertion(kvClient, key, value);
+
+      // 2. kvClient with namespace should see keys with such prefix
+      value = TestUtil.randomByteSequence();
+      assertEquals(false, putKVWithAssertion(kvClient, wKey, value, null));
+      assertExistentKey(kvClient, wKey, value);
+      assertExistentKey(kvClientWithNamespace, key, value);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 3. put the same key using the client with namespace
+      prevValue = value;
+      value = TestUtil.randomByteSequence();
+      assertEquals(true, putKVWithAssertion(kvClientWithNamespace, key, value, prevValue));
+      assertExistentKey(kvClient, wKey, value);
+      assertExistentKey(kvClientWithNamespace, key, value);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 4. delete the key using client with namespace
+      deleteKVWithAssertion(kvClientWithNamespace, key, value);
+    }
+
+    // test range
+    {
+      // prepare KVs in root, "namespace" and "namespace2"
+      List<TestKeyValue> kvsOfNoNamespace = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClient, kvsOfNoNamespace);
+      for (TestKeyValue keyValue : kvsOfNoNamespace) {
+        assertExistentKey(kvClient, keyValue.key, keyValue.value);
+      }
+      List<TestKeyValue> kvsOfNamespace = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace);
+      for (TestKeyValue keyValue : kvsOfNamespace) {
+        assertExistentKey(kvClientWithNamespace, keyValue.key, keyValue.value);
+      }
+      List<TestKeyValue> kvsOfNamespace2 = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2);
+      for (TestKeyValue keyValue : kvsOfNamespace2) {
+        assertExistentKey(kvClientWithNamespace2, keyValue.key, keyValue.value);
+      }
+
+      // get operations with namespace have been tested in previous cases, so here we only test
+      // get range operations.
+      assertExistentKVs(kvClient, kvsOfNoNamespace.get(0).key, END_KEY, kvsOfNoNamespace);
+      assertExistentKVs(kvClientWithNamespace, kvsOfNamespace.get(0).key, END_KEY, kvsOfNamespace);
+      assertExistentKVs(kvClientWithNamespace2, kvsOfNamespace2.get(0).key, END_KEY, kvsOfNamespace2);
+
+      assertExistentKVs(kvClient, kvsOfNoNamespace.get(0).key,
+          kvsOfNoNamespace.get(2).key, kvsOfNoNamespace.subList(0, 2));
+      assertExistentKVs(kvClientWithNamespace, kvsOfNamespace.get(1).key,
+          kvsOfNamespace.get(3).key, kvsOfNamespace.subList(1, 3));
+      assertExistentKVs(kvClientWithNamespace2, kvsOfNamespace2.get(1).key,
+          kvsOfNamespace2.get(3).key, kvsOfNamespace2.subList(1, 3));
+
+      // test deletion with key range
+      // delete part of keys in each namespace
+      deleteKVsWithAssertion(kvClient, kvsOfNoNamespace.get(0).key,
+          kvsOfNoNamespace.get(2).key, kvsOfNoNamespace.subList(0, 2));
+      deleteKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace.get(1).key,
+          kvsOfNamespace.get(3).key, kvsOfNamespace.subList(1, 3));
+      deleteKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2.get(1).key,
+          kvsOfNamespace2.get(3).key, kvsOfNamespace2.subList(1, 3));
+
+      // delete the rest of keys in each namespace
+      deleteKVsWithAssertion(kvClient, kvsOfNoNamespace.get(2).key, END_KEY,
+          kvsOfNoNamespace.subList(2, 3));
+      deleteKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace.get(3).key, END_KEY,
+          kvsOfNamespace.subList(3, 4));
+      deleteKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2.get(3).key, END_KEY,
+          kvsOfNamespace2.subList(3, 5));
+    }
+  }
+
+  @Test
+  public void testTxn() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+
+    // put a key in root namespace, assert that it cannot be seen using kvClient with namespace
+    ByteSequence cmpKey = getNonexistentKey();
+    putKVWithAssertion(kvClient, cmpKey, TestUtil.randomByteSequence(), null);
+
+    ByteSequence key1 = getNonexistentKey();
+    ByteSequence value1 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key1, value1, null);
+
+    ByteSequence key2 = getNonexistentKey();
+    ByteSequence value2 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key2, value2, null);
+
+    // test comparison passes, with put operation.
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // cmpKey doesn't exist in this namespace
+          .If(new Cmp(cmpKey, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.put(key1, TestUtil.randomByteSequence(),
+              PutOption.newBuilder().withPrevKV().build()))
+          .Else(Op.put(key2, TestUtil.randomByteSequence(),
+              PutOption.newBuilder().withPrevKV().build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertEquals(1, txnResponse.getPutResponses().size());
+      assertTrue(txnResponse.getPutResponses().get(0).hasPrevKv());
+      assertEquals(key1, txnResponse.getPutResponses().get(0).getPrevKv().getKey());
+      assertEquals(value1, txnResponse.getPutResponses().get(0).getPrevKv().getValue());
+    }
+
+    // test comparison fails, with get operation.
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // key1 exists in this namespace
+          .If(new Cmp(key1, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.get(key1, GetOption.newBuilder().build()))
+          .Else(Op.get(key2, GetOption.newBuilder().build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertEquals(1, txnResponse.getGetResponses().size());
+      assertEquals(1, txnResponse.getGetResponses().get(0).getKvs().size());
+      assertEquals(key2, txnResponse.getGetResponses().get(0).getKvs().get(0).getKey());
+      assertEquals(value2, txnResponse.getGetResponses().get(0).getKvs().get(0).getValue());
+    }
+
+    // test delete operation
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // key1 exists in this namespace
+          .If(new Cmp(key1, Cmp.Op.GREATER, CmpTarget.version(0)))
+          .Then(Op.delete(key2, DeleteOption.newBuilder().withPrevKV(true).build()))
+          .Else(Op.delete(key1, DeleteOption.newBuilder().withPrevKV(true).build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertEquals(1, txnResponse.getDeleteResponses().size());
+      assertEquals(1, txnResponse.getDeleteResponses().get(0).getPrevKvs().size());
+      assertEquals(key2, txnResponse.getDeleteResponses().get(0).getPrevKvs().get(0).getKey());
+      assertEquals(value2, txnResponse.getDeleteResponses().get(0).getPrevKvs().get(0).getValue());
+    }
+  }
+
+  @Test
+  public void testNestedTxn() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+
+    ByteSequence cmpKey1 = getNonexistentKey();
+    putKVWithAssertion(kvClient, cmpKey1, TestUtil.randomByteSequence(), null);
+
+    ByteSequence cmpKey2 = getNonexistentKey();
+    putKVWithAssertion(kvClientWithNamespace, cmpKey2, TestUtil.randomByteSequence(), null);
+
+    ByteSequence key1 = getNonexistentKey();
+    ByteSequence value1 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key1, value1, null);
+
+    ByteSequence key2 = getNonexistentKey();
+    ByteSequence value2 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key2, value2, null);
+
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      ByteSequence nextValue1 = TestUtil.randomByteSequence();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          .If(new Cmp(cmpKey1, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.txn(
+              new Cmp[] {new Cmp(cmpKey2, Cmp.Op.GREATER, CmpTarget.version(0))},
+              new Op[] {Op.put(key1, nextValue1,
+                  PutOption.newBuilder().withPrevKV().build())},
+              new Op[] {Op.put(key2, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())}
+          ))
+          .Else(Op.txn(
+              new Cmp[] {new Cmp(cmpKey2, Cmp.Op.GREATER, CmpTarget.version(0))},
+              new Op[] {Op.put(key2, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())},
+              new Op[] {Op.put(key1, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())}
+          )).commit();
+      TxnResponse response = txnFuture.get();
+      assertEquals(1, response.getTxnResponses().size());
+      assertEquals(1, response.getTxnResponses().get(0).getPutResponses().size());
+      assertEquals(true, response.getTxnResponses().get(0).getPutResponses().get(0).hasPrevKv());
+      assertEquals(key1, response.getTxnResponses().get(0).getPutResponses().get(0)
+          .getPrevKv().getKey());
+      assertEquals(value1, response.getTxnResponses().get(0).getPutResponses().get(0)
+          .getPrevKv().getValue());
+      value1 = nextValue1;
+      assertExistentKey(kvClient,
+          ByteSequence.from(namespace.getByteString().concat(key1.getByteString())), value1);
+    }
+  }
+
+  /********************************* Internal Test Utilities ******************************/
+
+  class TestKeyValue {
+    ByteSequence key;
+    ByteSequence value;
+
+    TestKeyValue(ByteSequence key, ByteSequence value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+
+  private static ByteSequence getNonexistentKey() {
+    synchronized (keyIndex) {
+      keyIndex++;
+      return ByteSequence.from("sample_key_" + String.format("%05d", keyIndex), Charsets.UTF_8);
+    }
+  }
+
+  private static void assertNonexistentKey(KV kvClient, ByteSequence key) throws Exception {
+    CompletableFuture<GetResponse> getFeature = kvClient.get(key);
+    GetResponse response = getFeature.get();
+    assertEquals(0, response.getKvs().size());
+  }
+
+  private static void assertExistentKey(KV kvClient, ByteSequence key, ByteSequence value)
+      throws Exception {
+    CompletableFuture<GetResponse> getFeature = kvClient.get(key);
+    GetResponse response = getFeature.get();
+    assertEquals(1, response.getKvs().size());
+    assertEquals(key, response.getKvs().get(0).getKey());
+    assertEquals(value, response.getKvs().get(0).getValue());
+  }
+
+  /**
+   * Put key-value pair and return whether has previous KV.
+   */
+  private static boolean putKVWithAssertion(
+      KV kvClient, ByteSequence key, ByteSequence value, ByteSequence prevValue) throws Exception {
+    CompletableFuture<PutResponse> feature = kvClient.put(key, value,
+        PutOption.newBuilder().withPrevKV().build());
+    PutResponse response = feature.get();
+    if (prevValue != null) {
+      assertEquals(true, response.hasPrevKv());
+      assertEquals(key, response.getPrevKv().getKey());
+      assertEquals(prevValue, response.getPrevKv().getValue());
+    }
+    return response.hasPrevKv();
+  }
+
+  private static void deleteKVWithAssertion(KV kvClient, ByteSequence key, ByteSequence prevValue)
+      throws Exception {
+    CompletableFuture<DeleteResponse> deleteFuture = kvClient.delete(key,
+        DeleteOption.newBuilder().withPrevKV(true).build());
+    DeleteResponse deleteResponse = deleteFuture.get();
+    assertEquals(1, deleteResponse.getDeleted());
+    assertEquals(1, deleteResponse.getPrevKvs().size());
+    assertEquals(key, deleteResponse.getPrevKvs().get(0).getKey());
+    assertEquals(prevValue, deleteResponse.getPrevKvs().get(0).getValue());
+    assertNonexistentKey(kvClient, key);
+  }
+
+  private static void putKVsWithAssertion(KV kvClient, List<TestKeyValue> keyValues)
+      throws Exception {
+    for (TestKeyValue keyValue : keyValues) {
+      putKVWithAssertion(kvClient, keyValue.key, keyValue.value, null);
+    }
+  }
+
+  private static void assertExistentKVs(KV kvClient, ByteSequence key, ByteSequence end,
+      List<TestKeyValue> expectedKVs) throws Exception {
+    CompletableFuture<GetResponse> getFuture = kvClient.get(key, GetOption.newBuilder()
+        .withRange(end).build());
+    GetResponse getResponse = getFuture.get();
+    assertEquals(expectedKVs.size(), getResponse.getKvs().size());
+    for (KeyValue keyValue : getResponse.getKvs()) {
+      boolean exist = false;
+      for (TestKeyValue expectedKV : expectedKVs) {
+        if (expectedKV.key.equals(keyValue.getKey())) {
+          exist = true;
+          assertEquals(expectedKV.value, keyValue.getValue());
+          break;
+        }
+      }
+      assertTrue(exist);
+    }
+  }
+
+  private static void deleteKVsWithAssertion(KV kvClient, ByteSequence key, ByteSequence end,
+      List<TestKeyValue> previousKVs) throws Exception {
+    CompletableFuture<DeleteResponse> deleteFuture = kvClient.delete(key,
+        DeleteOption.newBuilder().withRange(end).withPrevKV(true).build());
+    DeleteResponse deleteResponse = deleteFuture.get();
+    assertEquals(previousKVs.size(), deleteResponse.getDeleted());
+    assertEquals(previousKVs.size(), deleteResponse.getPrevKvs().size());
+    for (KeyValue keyValue : deleteResponse.getPrevKvs()) {
+      boolean exist = false;
+      for (TestKeyValue previousKV : previousKVs) {
+        if (previousKV.key.equals(keyValue.getKey())) {
+          exist = true;
+          assertEquals(previousKV.value, keyValue.getValue());
+          break;
+        }
+      }
+      assertTrue(exist);
+    }
+  }
+}

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LockTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LockTest.java
@@ -25,10 +25,12 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.asserts.Assertion;
 
@@ -44,6 +46,13 @@ public class LockTest {
   private Set<ByteSequence> locksToRelease;
 
   private static final ByteSequence SAMPLE_NAME = ByteSequence.from("sample_name", Charsets.UTF_8);
+  private static final ByteSequence namespace = ByteSequence.from("test-ns/", Charsets.UTF_8);
+  private static final ByteSequence namespace2 = ByteSequence.from("test-ns2/", Charsets.UTF_8);
+
+  @DataProvider(name = "NamespaceTest")
+  public static Object[][] parameters() {
+    return new Boolean[][] {{true}, {false}};
+  }
 
   @BeforeTest
   public void setUp() throws Exception {
@@ -52,7 +61,6 @@ public class LockTest {
     Client client = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build();
 
     test = new Assertion();
-    lockClient = client.getLockClient();
     leaseClient = client.getLeaseClient();
   }
 
@@ -68,8 +76,16 @@ public class LockTest {
     }
   }
 
-  @Test
-  public void testLockWithoutLease() throws Exception {
+  private void initializeLockCLient(boolean useNamespace) {
+    Client client = useNamespace
+        ? Client.builder().endpoints(CLUSTER.getClientEndpoints()).namespace(namespace).build()
+        : Client.builder().endpoints(CLUSTER.getClientEndpoints()).build();
+    this.lockClient = client.getLockClient();
+  }
+
+  @Test(dataProvider = "NamespaceTest")
+  public void testLockWithoutLease(boolean useNamespace) throws Exception {
+    initializeLockCLient(useNamespace);
     CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, 0);
     LockResponse response = feature.get();
     locksToRelease.add(response.getKey());
@@ -79,15 +95,18 @@ public class LockTest {
   }
 
   @Test(expectedExceptions = ExecutionException.class,
-      expectedExceptionsMessageRegExp = ".*etcdserver: requested lease not found")
-  public void testLockWithNotExistingLease() throws Exception {
+      expectedExceptionsMessageRegExp = ".*etcdserver: requested lease not found",
+      dataProvider = "NamespaceTest")
+  public void testLockWithNotExistingLease(boolean useNamespace) throws Exception {
+    initializeLockCLient(useNamespace);
     CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, 123456);
     LockResponse response = feature.get();
     locksToRelease.add(response.getKey());
   }
 
-  @Test
-  public void testLockWithLease() throws Exception {
+  @Test(dataProvider = "NamespaceTest")
+  public void testLockWithLease(boolean useNamespace) throws Exception {
+    initializeLockCLient(useNamespace);
     long lease = grantLease(5);
     CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, lease);
     LockResponse response = feature.get();
@@ -107,8 +126,9 @@ public class LockTest {
     locksToRelease.add(response2.getKey());
   }
 
-  @Test
-  public void testLockAndUnlock() throws Exception {
+  @Test(dataProvider = "NamespaceTest")
+  public void testLockAndUnlock(boolean useNamespace) throws Exception {
+    initializeLockCLient(useNamespace);
     long lease = grantLease(20);
     CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, lease);
     LockResponse response = feature.get();
@@ -127,6 +147,63 @@ public class LockTest {
     test.assertNotEquals(response.getKey(), response2.getKey());
     test.assertTrue(time <= 500,
         String.format("Lease not unlocked, wait time was too long (%dms)", time));
+  }
+
+  @Test
+  public void testLockSegregationByNamespaces() throws Exception {
+    initializeLockCLient(false);
+
+    // prepare two LockClients with different namespaces, lock operations on one LockClient
+    // should have no effect on the other client.
+    Client clientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build();
+    Lock lockClientWithNamespace = clientWithNamespace.getLockClient();
+
+    Client clientWithNamespace2 = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace2).build();
+    Lock lockClientWithNamespace2 = clientWithNamespace2.getLockClient();
+
+    long lease = grantLease(5);
+    CompletableFuture<LockResponse> feature = lockClientWithNamespace.lock(SAMPLE_NAME, lease);
+    LockResponse response = feature.get();
+
+    long startTime = System.currentTimeMillis();
+
+    test.assertTrue(response.getKey().startsWith(SAMPLE_NAME));
+
+    // Unlock by full key name using LockClient without namespace, thus it should not take
+    // much time to lock the same key again.
+    ByteSequence wKey = ByteSequence.from(namespace.getByteString().concat(
+        response.getKey().getByteString()));
+    lockClient.unlock(wKey).get();
+    lease = grantLease(30);
+    CompletableFuture<LockResponse> feature2 = lockClientWithNamespace.lock(SAMPLE_NAME, lease);
+    LockResponse response2 = feature2.get();
+
+    long timestamp2 = System.currentTimeMillis();
+
+    test.assertTrue(response2.getKey().startsWith(SAMPLE_NAME));
+    test.assertNotEquals(response.getKey(), response2.getKey());
+    test.assertTrue((timestamp2 - startTime) <= 1000, String.format(
+        "Lease not unlocked, wait time was too long (%dms)", (timestamp2 - startTime)));
+
+    locksToRelease.add(ByteSequence.from(namespace.getByteString().concat(
+        response2.getKey().getByteString())));
+
+    // Lock the same key using LockClient with another namespace, it also should not take much time.
+    lease = grantLease(5);
+    CompletableFuture<LockResponse> feature3 = lockClientWithNamespace2.lock(SAMPLE_NAME, lease);
+    LockResponse response3 = feature3.get();
+
+    long timestamp3 = System.currentTimeMillis();
+
+    test.assertTrue(response3.getKey().startsWith(SAMPLE_NAME));
+    test.assertNotEquals(response3.getKey(), response2.getKey());
+    test.assertTrue((timestamp3 - timestamp2) <= 1000, String.format(
+        "wait time for requiring the lock was too long (%dms)", (timestamp3 - timestamp2)));
+
+    locksToRelease.add(ByteSequence.from(namespace2.getByteString().concat(
+        response3.getKey().getByteString())));
   }
 
   private long grantLease(long ttl) throws Exception {


### PR DESCRIPTION
This PR enables users to specify a namespace for each key used in jetcd client.

Fixes #472 