### PR TITLE
jetcd-core: support namespace in jetcd client

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -109,6 +109,29 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
             <scope>test</scope>

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -23,6 +23,9 @@ import java.nio.charset.Charset;
  * Etcd binary bytes, easy to convert between byte[], String and ByteString.
  */
 public final class ByteSequence {
+  public static final ByteSequence EMPTY = new ByteSequence(ByteString.EMPTY);
+  public static final ByteSequence NAMESPACE_DELIMITER = ByteSequence.from(new byte[] {'/'});
+
   private final int hashVal;
   private final ByteString byteString;
 
@@ -68,6 +71,14 @@ public final class ByteSequence {
 
   public byte[] getBytes() {
     return byteString.toByteArray();
+  }
+
+  public boolean isEmpty() {
+    return byteString.isEmpty();
+  }
+
+  public int size() {
+    return byteString.size();
   }
 
   /**

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -57,6 +57,7 @@ public final class ClientBuilder implements Cloneable {
   private Integer maxInboundMessageSize;
   private Map<Metadata.Key, Object> headers;
   private List<ClientInterceptor> interceptors;
+  private ByteSequence namespace = ByteSequence.EMPTY;
 
   ClientBuilder() {
   }
@@ -139,6 +140,24 @@ public final class ClientBuilder implements Cloneable {
   public ClientBuilder password(ByteSequence password) {
     checkNotNull(password, "password can't be null");
     this.password = password;
+    return this;
+  }
+
+  public ByteSequence namespace() {
+    return namespace;
+  }
+
+  /**
+   * config the namespace of keys used in {@code KV}, {@code Txn}, {@code Lock} and {@code Watch}.
+   * "/" will be treated as no namespace.
+   *
+   * @param namespace the namespace of each key used
+   * @return this builder
+   * @throws NullPointerException if namespace is <code>null</code>
+   */
+  public ClientBuilder namespace(ByteSequence namespace) {
+    checkNotNull(namespace, "namespace can't be null");
+    this.namespace = namespace;
     return this;
   }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -120,6 +120,9 @@ final class ClientConnectionManager {
     }
   }
 
+  ByteSequence getNamespace() {
+    return builder.namespace();
+  }
 
   ExecutorService getExecutorService() {
     return executorService;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
@@ -46,9 +46,12 @@ final class KVImpl implements KV {
 
   private final KVGrpc.KVFutureStub stub;
 
+  private final ByteSequence namespace;
+
   KVImpl(ClientConnectionManager connectionManager) {
     this.connectionManager = connectionManager;
     this.stub = connectionManager.newStub(KVGrpc::newFutureStub);
+    this.namespace = connectionManager.getNamespace();
   }
 
   @Override
@@ -64,7 +67,7 @@ final class KVImpl implements KV {
     checkNotNull(option, "option should not be null");
 
     PutRequest request = PutRequest.newBuilder()
-        .setKey(key.getByteString())
+        .setKey(Util.prefixNamespace(key.getByteString(), namespace))
         .setValue(value.getByteString())
         .setLease(option.getLeaseId())
         .setPrevKv(option.getPrevKV())
@@ -72,7 +75,7 @@ final class KVImpl implements KV {
 
     return Util.toCompletableFutureWithRetry(
         () -> stub.put(request),
-        PutResponse::new,
+        response -> new PutResponse(response, namespace),
         Util::isRetriable,
         connectionManager.getExecutorService()
     );
@@ -89,7 +92,7 @@ final class KVImpl implements KV {
     checkNotNull(option, "option should not be null");
 
     RangeRequest.Builder builder = RangeRequest.newBuilder()
-        .setKey(key.getByteString())
+        .setKey(Util.prefixNamespace(key.getByteString(), namespace))
         .setCountOnly(option.isCountOnly())
         .setLimit(option.getLimit())
         .setRevision(option.getRevision())
@@ -99,14 +102,14 @@ final class KVImpl implements KV {
         .setSortTarget(toRangeRequestSortTarget(option.getSortField()));
 
     option.getEndKey()
-      .map(ByteSequence::getByteString)
+      .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
       .ifPresent(builder::setRangeEnd);
 
     RangeRequest request = builder.build();
 
     return Util.toCompletableFutureWithRetry(
         () -> stub.range(request),
-        GetResponse::new,
+        response -> new GetResponse(response, namespace),
         Util::isRetriable,
         connectionManager.getExecutorService()
     );
@@ -123,18 +126,18 @@ final class KVImpl implements KV {
     checkNotNull(option, "option should not be null");
 
     DeleteRangeRequest.Builder builder = DeleteRangeRequest.newBuilder()
-        .setKey(key.getByteString())
+        .setKey(Util.prefixNamespace(key.getByteString(), namespace))
         .setPrevKv(option.isPrevKV());
 
     option.getEndKey()
-      .map(ByteSequence::getByteString)
+      .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
       .ifPresent(builder::setRangeEnd);
 
     DeleteRangeRequest request = builder.build();
 
     return Util.toCompletableFutureWithRetry(
         () -> stub.deleteRange(request),
-        DeleteResponse::new,
+        response -> new DeleteResponse(response, namespace),
         Util::isRetriable,
         connectionManager.getExecutorService()
     );
@@ -166,10 +169,10 @@ final class KVImpl implements KV {
     return TxnImpl.newTxn((request) ->
         Util.toCompletableFutureWithRetry(
             () -> stub.txn(request),
-            TxnResponse::new,
+            response -> new TxnResponse(response, namespace),
             Util::isRetriable,
             connectionManager.getExecutorService()
-        )
-    );
+        ),
+        namespace);
   }
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
@@ -21,18 +21,23 @@ package io.etcd.jetcd;
  */
 public class KeyValue {
 
-  private io.etcd.jetcd.api.KeyValue kv;
+  private final io.etcd.jetcd.api.KeyValue kv;
+  private final ByteSequence unprefixedKey;
+  private final ByteSequence value;
 
-  public KeyValue(io.etcd.jetcd.api.KeyValue kv) {
+  public KeyValue(io.etcd.jetcd.api.KeyValue kv, ByteSequence namespace) {
     this.kv = kv;
+    this.unprefixedKey = ByteSequence.from(kv.getKey().isEmpty() ? kv.getKey()
+        : Util.unprefixNamespace(kv.getKey(), namespace));
+    this.value = ByteSequence.from(kv.getValue());
   }
 
   public ByteSequence getKey() {
-    return ByteSequence.from(kv.getKey());
+    return unprefixedKey;
   }
 
   public ByteSequence getValue() {
-    return ByteSequence.from(kv.getValue());
+    return value;
   }
 
   public long getCreateRevision() {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
@@ -23,6 +23,7 @@ import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.toEtcdExceptio
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
 import io.etcd.jetcd.common.exception.ErrorCode;
 import io.grpc.Status;
 import java.net.URI;
@@ -227,6 +228,40 @@ public final class Util {
     // system in an inconsistent state, but retrying could make progress.
     // (e.g., failed in middle of send, corrupted frame)
     return status.getCode() != Status.Code.UNAVAILABLE && status.getCode() != Status.Code.INTERNAL;
+  }
+
+  public static ByteString prefixNamespace(ByteString key, ByteSequence namespace) {
+    return namespace.isEmpty() ? key : namespace.getByteString().concat(key);
+  }
+
+  public static ByteString prefixNamespaceToRangeEnd(ByteString end, ByteSequence namespace) {
+    if (namespace.isEmpty()) {
+      return end;
+    }
+
+    if (end.size() == 1 && end.toByteArray()[0] == 0) {
+      // range end is '\0', calculate the prefixed range end by (key + 1)
+      byte[] prefixedEndArray = namespace.getByteString().toByteArray();
+      boolean ok = false;
+      for (int i = (prefixedEndArray.length - 1); i >= 0; i--) {
+        prefixedEndArray[i] = (byte) (prefixedEndArray[i] + 1);
+        if (prefixedEndArray[i] != 0) {
+          ok = true;
+          break;
+        }
+      }
+      if (!ok) {
+        // 0xff..ff => 0x00
+        prefixedEndArray = new byte[] {0};
+      }
+      return ByteString.copyFrom(prefixedEndArray);
+    } else {
+      return namespace.getByteString().concat(end);
+    }
+  }
+
+  public static ByteString unprefixNamespace(ByteString key, ByteSequence namespace) {
+    return namespace.isEmpty() ? key : key.substring(namespace.size());
   }
 
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -54,6 +54,7 @@ final class WatchImpl implements Watch {
   private final ListeningScheduledExecutorService executor;
   private final AtomicBoolean closed;
   private final List<WatcherImpl> watchers;
+  private final ByteSequence namespace;
 
   WatchImpl(ClientConnectionManager connectionManager) {
     this.lock = new Object();
@@ -62,6 +63,7 @@ final class WatchImpl implements Watch {
     this.executor = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
     this.closed = new AtomicBoolean();
     this.watchers = new ArrayList<>();
+    this.namespace = connectionManager.getNamespace();
   }
 
   @Override
@@ -129,13 +131,13 @@ final class WatchImpl implements Watch {
         id = -1;
 
         WatchCreateRequest.Builder builder = WatchCreateRequest.newBuilder()
-            .setKey(this.key.getByteString())
+            .setKey(Util.prefixNamespace(this.key.getByteString(), namespace))
             .setPrevKv(this.option.isPrevKV())
             .setProgressNotify(option.isProgressNotify())
             .setStartRevision(this.revision);
 
         option.getEndKey()
-            .map(ByteSequence::getByteString)
+            .map(endKey -> Util.prefixNamespaceToRangeEnd(endKey.getByteString(), namespace))
             .ifPresent(builder::setRangeEnd);
 
         if (option.isNoDelete()) {
@@ -227,10 +229,10 @@ final class WatchImpl implements Watch {
         // For more info:
         //   https://coreos.com/etcd/docs/latest/learning/api.html#watch-streams
         //
-        listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));
+        listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response, namespace));
         revision = response.getHeader().getRevision();
       } else if (response.getEventsCount() > 0) {
-        listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response));
+        listener.onNext(new io.etcd.jetcd.watch.WatchResponse(response, namespace));
         revision = response.getEvents(response.getEventsCount() - 1).getKv().getModRevision() + 1;
       }
     }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.api.DeleteRangeResponse;
 import java.util.List;
@@ -24,10 +25,13 @@ import java.util.stream.Collectors;
 
 public class DeleteResponse extends AbstractResponse<DeleteRangeResponse> {
 
+  private final ByteSequence namespace;
+
   private List<KeyValue> prevKvs;
 
-  public DeleteResponse(DeleteRangeResponse deleteRangeResponse) {
+  public DeleteResponse(DeleteRangeResponse deleteRangeResponse, ByteSequence namespace) {
     super(deleteRangeResponse, deleteRangeResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
@@ -43,7 +47,7 @@ public class DeleteResponse extends AbstractResponse<DeleteRangeResponse> {
   public synchronized List<KeyValue> getPrevKvs() {
     if (prevKvs == null) {
       prevKvs = getResponse().getPrevKvsList().stream()
-          .map(KeyValue::new)
+          .map(kv -> new KeyValue(kv, namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.api.RangeResponse;
 import java.util.List;
@@ -24,10 +25,13 @@ import java.util.stream.Collectors;
 
 public class GetResponse extends AbstractResponse<RangeResponse> {
 
+  private final ByteSequence namespace;
+
   private List<KeyValue> kvs;
 
-  public GetResponse(RangeResponse rangeResponse) {
+  public GetResponse(RangeResponse rangeResponse, ByteSequence namespace) {
     super(rangeResponse, rangeResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
@@ -36,7 +40,7 @@ public class GetResponse extends AbstractResponse<RangeResponse> {
   public synchronized List<KeyValue> getKvs() {
     if (kvs == null) {
       kvs = getResponse().getKvsList().stream()
-          .map(KeyValue::new)
+          .map(kv -> new KeyValue(kv, namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
@@ -17,19 +17,23 @@
 package io.etcd.jetcd.kv;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KeyValue;
 
 public class PutResponse extends AbstractResponse<io.etcd.jetcd.api.PutResponse> {
 
-  public PutResponse(io.etcd.jetcd.api.PutResponse putResponse) {
+  private final ByteSequence namespace;
+
+  public PutResponse(io.etcd.jetcd.api.PutResponse putResponse, ByteSequence namespace) {
     super(putResponse, putResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
    * return previous key-value pair.
    */
   public KeyValue getPrevKv() {
-    return new KeyValue(getResponse().getPrevKv());
+    return new KeyValue(getResponse().getPrevKv(), namespace);
   }
 
   public boolean hasPrevKv() {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
@@ -22,6 +22,8 @@ import static io.etcd.jetcd.api.ResponseOp.ResponseCase.RESPONSE_RANGE;
 import static io.etcd.jetcd.api.ResponseOp.ResponseCase.RESPONSE_TXN;
 
 import io.etcd.jetcd.AbstractResponse;
+import io.etcd.jetcd.ByteSequence;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,15 +33,17 @@ import java.util.stream.Collectors;
  */
 public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse> {
 
-  // TODO add txnResponsesRef when nested txn is implemented.
+  private final ByteSequence namespace;
+
   private List<PutResponse> putResponses;
   private List<GetResponse> getResponses;
   private List<DeleteResponse> deleteResponses;
   private List<TxnResponse> txnResponses;
 
 
-  public TxnResponse(io.etcd.jetcd.api.TxnResponse txnResponse) {
+  public TxnResponse(io.etcd.jetcd.api.TxnResponse txnResponse, ByteSequence namespace) {
     super(txnResponse, txnResponse.getHeader());
+    this.namespace = namespace;
   }
 
   /**
@@ -56,7 +60,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (deleteResponses == null) {
       deleteResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_DELETE_RANGE)
-          .map(responseOp -> new DeleteResponse(responseOp.getResponseDeleteRange()))
+          .map(responseOp -> new DeleteResponse(responseOp.getResponseDeleteRange(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -70,7 +74,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (getResponses == null) {
       getResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_RANGE)
-          .map(responseOp -> new GetResponse(responseOp.getResponseRange()))
+          .map(responseOp -> new GetResponse(responseOp.getResponseRange(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -84,7 +88,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (putResponses == null) {
       putResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_PUT)
-          .map(responseOp -> new PutResponse(responseOp.getResponsePut()))
+          .map(responseOp -> new PutResponse(responseOp.getResponsePut(), namespace))
           .collect(Collectors.toList());
     }
 
@@ -95,7 +99,7 @@ public class TxnResponse extends AbstractResponse<io.etcd.jetcd.api.TxnResponse>
     if (txnResponses == null) {
       txnResponses = getResponse().getResponsesList().stream()
           .filter((responseOp) -> responseOp.getResponseCase() == RESPONSE_TXN)
-          .map(responseOp -> new TxnResponse(responseOp.getResponseTxn()))
+          .map(responseOp -> new TxnResponse(responseOp.getResponseTxn(), namespace))
           .collect(Collectors.toList());
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
@@ -18,11 +18,15 @@ package io.etcd.jetcd.lock;
 
 import io.etcd.jetcd.AbstractResponse;
 import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Util;
 
 public class LockResponse extends AbstractResponse<io.etcd.jetcd.api.lock.LockResponse> {
 
-  public LockResponse(io.etcd.jetcd.api.lock.LockResponse response) {
+  private final ByteSequence unprefixedKey;
+
+  public LockResponse(io.etcd.jetcd.api.lock.LockResponse response, ByteSequence namespace) {
     super(response, response.getHeader());
+    this.unprefixedKey = ByteSequence.from(Util.unprefixNamespace(getResponse().getKey(), namespace));
   }
 
   /**
@@ -31,7 +35,7 @@ public class LockResponse extends AbstractResponse<io.etcd.jetcd.api.lock.LockRe
    * undefined behavior.
    */
   public ByteSequence getKey() {
-    return ByteSequence.from(getResponse().getKey());
+    return unprefixedKey;
   }
 
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
@@ -18,10 +18,11 @@ package io.etcd.jetcd.op;
 
 import com.google.protobuf.ByteString;
 import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Util;
 import io.etcd.jetcd.api.Compare;
 
 /**
- * The compare predicate in {@link Txn}.
+ * The compare predicate in {@link io.etcd.jetcd.Txn}.
  */
 public class Cmp {
 
@@ -39,8 +40,9 @@ public class Cmp {
     this.target = target;
   }
 
-  Compare toCompare() {
-    Compare.Builder compareBuilder = Compare.newBuilder().setKey(this.key);
+  Compare toCompare(ByteSequence namespace) {
+    Compare.Builder compareBuilder = Compare.newBuilder().setKey(
+        Util.prefixNamespace(this.key, namespace));
     switch (this.op) {
       case EQUAL:
         compareBuilder.setResult(Compare.CompareResult.EQUAL);

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
@@ -16,33 +16,42 @@
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.base.Charsets;
 import io.grpc.netty.NettyChannelBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Random;
-import org.junit.Test;
+import java.util.stream.Stream;
+
 
 public class ClientBuilderTest {
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testEndPoints_Null() {
-    Client.builder().endpoints((URI)null);
+    assertThrows(NullPointerException.class, () -> Client.builder().endpoints((URI)null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEndPoints_Verify_Empty() throws URISyntaxException {
-    Client.builder().endpoints(new URI(""));
+    assertThrows(IllegalArgumentException.class, () -> Client.builder().endpoints(new URI("")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEndPoints_Verify_SomeEmpty() throws URISyntaxException {
-    Client.builder().endpoints(new URI("http://127.0.0.1:2379"), new URI(""));
+    assertThrows(IllegalArgumentException.class,
+        () -> Client.builder().endpoints(new URI("http://127.0.0.1:2379"), new URI("")));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBuild_WithoutEndpoints() {
-    Client.builder().build();
+    assertThrows(IllegalStateException.class, () -> Client.builder().build());
   }
 
   @Test
@@ -53,4 +62,34 @@ public class ClientBuilderTest {
 
     assertThat(channelBuilder).hasFieldOrPropertyWithValue("maxInboundMessageSize", value);
   }
+
+  @Test
+  public void testDefaultNamespace() throws URISyntaxException {
+    // test default namespace setting
+    final ClientBuilder builder =  Client.builder().endpoints(new URI("http://127.0.0.1:2379"));
+    final ClientConnectionManager connectionManager = new ClientConnectionManager(builder);
+    assertThat(connectionManager.getNamespace()).isEqualTo(ByteSequence.EMPTY);
+  }
+
+  static Stream<Arguments> namespaceProvider() {
+    return Stream.of(
+        // namespace setting, expected namespace
+        Arguments.of(ByteSequence.EMPTY, ByteSequence.EMPTY),
+        Arguments.of(ByteSequence.from("/namespace1/", Charsets.UTF_8),
+            ByteSequence.from("/namespace1/", Charsets.UTF_8)),
+        Arguments.of(ByteSequence.from("namespace2/", Charsets.UTF_8),
+            ByteSequence.from("namespace2/", Charsets.UTF_8))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("namespaceProvider")
+  public void testNamespace(ByteSequence namespaceSetting, ByteSequence expectedNamespace)
+      throws URISyntaxException {
+      final ClientBuilder builder =  Client.builder().endpoints(new URI("http://127.0.0.1:2379"))
+          .namespace(namespaceSetting);
+      final ClientConnectionManager connectionManager = new ClientConnectionManager(builder);
+      assertThat(connectionManager.getNamespace()).isEqualTo(expectedNamespace);
+  }
+
 }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
@@ -1,0 +1,493 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.etcd.jetcd;
+
+import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+import io.etcd.jetcd.kv.DeleteResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.kv.TxnResponse;
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import io.etcd.jetcd.op.Cmp;
+import io.etcd.jetcd.op.CmpTarget;
+import io.etcd.jetcd.op.Op;
+import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.PutOption;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases focusing on using KVClient and TxnClient with non-empty namespace.
+ */
+public class KVNamespaceTest {
+  private static final ByteSequence END_KEY = ByteSequence.from(new byte[] {0});
+
+  public static final EtcdCluster CLUSTER = EtcdClusterFactory.buildCluster(
+      "etcd-kv-namespace-test", 3 ,false);
+  private KV kvClient;
+  private KV kvClientWithNamespace;
+  private KV kvClientWithNamespace2;
+
+  private static Integer keyIndex = -1;
+
+  @BeforeAll
+  public static void setUp() {
+    CLUSTER.start();
+  }
+
+  @AfterAll
+  public static void tearDown() throws IOException {
+    CLUSTER.close();
+  }
+
+  @AfterEach
+  public void cleanUpCase() {
+    if (kvClient != null) {
+      kvClient.close();
+      kvClient = null;
+    }
+    if (kvClientWithNamespace != null) {
+      kvClientWithNamespace.close();
+      kvClientWithNamespace = null;
+    }
+    if (kvClientWithNamespace2 != null) {
+      kvClientWithNamespace2.close();
+      kvClientWithNamespace2 = null;
+    }
+  }
+
+  static Stream<Arguments> namespaceProvider() {
+    return Stream.of(
+        // namespace, key, end, wKey, wEnd
+        // 1. single key
+        Arguments.of(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("a".getBytes(Charsets.UTF_8)),
+            null,
+            ByteString.copyFrom("pfx/a".getBytes(Charsets.UTF_8)),
+            null),
+        // 2. range
+        Arguments.of(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("def".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx/def".getBytes(Charsets.UTF_8))),
+        // 3. one-sided range
+        Arguments.of(
+            ByteSequence.from("pfx/", Charsets.UTF_8),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom(new byte[] {0}),
+            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom("pfx0".getBytes(Charsets.UTF_8))),
+        // 4. one-sided range, end of key space
+        Arguments.of(
+            ByteSequence.from(new byte[] {(byte) 0xff, (byte) 0xff}),
+            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            ByteString.copyFrom(new byte[] {0}),
+            ByteString.copyFrom(new byte[] {(byte) 0xff, (byte) 0xff, 'a', 'b', 'c'}),
+            ByteString.copyFrom(new byte[] {0}))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("namespaceProvider")
+  public void testPrefixNamespace(
+      ByteSequence namespace, ByteString key, ByteString end,
+      ByteString expectedWKey, ByteString expectedWEnd) {
+      ByteString wKey = Util.prefixNamespace(key, namespace);
+      assertThat(wKey).isEqualTo(expectedWKey);
+      if (end != null) {
+        ByteString wEnd = Util.prefixNamespaceToRangeEnd(end, namespace);
+        assertThat(wEnd).isEqualTo(expectedWEnd);
+      }
+  }
+
+  @Test
+  public void testKV() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+    // kvClient with another namespace used to test keyed segregation based on namespace
+    ByteSequence namespace2 = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace2 = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace2).build().getKVClient();
+
+    // test single key
+    {
+      ByteSequence key = getNonexistentKey();
+      ByteSequence wKey = ByteSequence.from(namespace.getByteString().concat(key.getByteString()));
+      ByteSequence value = null;
+      ByteSequence prevValue = null;
+
+      assertNonexistentKey(kvClient, wKey);
+      assertNonexistentKey(kvClientWithNamespace, key);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 1. kvClient with namespace should not see keys without such prefix
+      value = TestUtil.randomByteSequence();
+      assertThat(putKVWithAssertion(kvClient, key, value, null)).isFalse();
+      assertExistentKey(kvClient, key, value);
+      assertNonexistentKey(kvClientWithNamespace, key);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+      deleteKVWithAssertion(kvClient, key, value);
+
+      // 2. kvClient with namespace should see keys with such prefix
+      value = TestUtil.randomByteSequence();
+      assertThat(putKVWithAssertion(kvClient, wKey, value, null)).isFalse();
+      assertExistentKey(kvClient, wKey, value);
+      assertExistentKey(kvClientWithNamespace, key, value);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 3. put the same key using the client with namespace
+      prevValue = value;
+      value = TestUtil.randomByteSequence();
+      assertThat(putKVWithAssertion(kvClientWithNamespace, key, value, prevValue)).isTrue();
+      assertExistentKey(kvClient, wKey, value);
+      assertExistentKey(kvClientWithNamespace, key, value);
+      assertNonexistentKey(kvClientWithNamespace2, key);
+
+      // 4. delete the key using client with namespace
+      deleteKVWithAssertion(kvClientWithNamespace, key, value);
+    }
+
+    // test range
+    {
+      // prepare KVs in root, "namespace" and "namespace2"
+      List<TestKeyValue> kvsOfNoNamespace = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClient, kvsOfNoNamespace);
+      for (TestKeyValue keyValue : kvsOfNoNamespace) {
+        assertExistentKey(kvClient, keyValue.key, keyValue.value);
+      }
+      List<TestKeyValue> kvsOfNamespace = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace);
+      for (TestKeyValue keyValue : kvsOfNamespace) {
+        assertExistentKey(kvClientWithNamespace, keyValue.key, keyValue.value);
+      }
+      List<TestKeyValue> kvsOfNamespace2 = Arrays.asList(
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence()),
+          new TestKeyValue(getNonexistentKey(), TestUtil.randomByteSequence())
+      );
+      putKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2);
+      for (TestKeyValue keyValue : kvsOfNamespace2) {
+        assertExistentKey(kvClientWithNamespace2, keyValue.key, keyValue.value);
+      }
+
+      // get operations with namespace have been tested in previous cases, so here we only test
+      // get range operations.
+      assertExistentKVs(kvClient, kvsOfNoNamespace.get(0).key, END_KEY, kvsOfNoNamespace);
+      assertExistentKVs(kvClientWithNamespace, kvsOfNamespace.get(0).key, END_KEY, kvsOfNamespace);
+      assertExistentKVs(kvClientWithNamespace2, kvsOfNamespace2.get(0).key, END_KEY, kvsOfNamespace2);
+
+      assertExistentKVs(kvClient, kvsOfNoNamespace.get(0).key,
+          kvsOfNoNamespace.get(2).key, kvsOfNoNamespace.subList(0, 2));
+      assertExistentKVs(kvClientWithNamespace, kvsOfNamespace.get(1).key,
+          kvsOfNamespace.get(3).key, kvsOfNamespace.subList(1, 3));
+      assertExistentKVs(kvClientWithNamespace2, kvsOfNamespace2.get(1).key,
+          kvsOfNamespace2.get(3).key, kvsOfNamespace2.subList(1, 3));
+
+      // test deletion with key range
+      // delete part of keys in each namespace
+      deleteKVsWithAssertion(kvClient, kvsOfNoNamespace.get(0).key,
+          kvsOfNoNamespace.get(2).key, kvsOfNoNamespace.subList(0, 2));
+      deleteKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace.get(1).key,
+          kvsOfNamespace.get(3).key, kvsOfNamespace.subList(1, 3));
+      deleteKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2.get(1).key,
+          kvsOfNamespace2.get(3).key, kvsOfNamespace2.subList(1, 3));
+
+      // delete the rest of keys in each namespace
+      deleteKVsWithAssertion(kvClient, kvsOfNoNamespace.get(2).key, END_KEY,
+          kvsOfNoNamespace.subList(2, 3));
+      deleteKVsWithAssertion(kvClientWithNamespace, kvsOfNamespace.get(3).key, END_KEY,
+          kvsOfNamespace.subList(3, 4));
+      deleteKVsWithAssertion(kvClientWithNamespace2, kvsOfNamespace2.get(3).key, END_KEY,
+          kvsOfNamespace2.subList(3, 5));
+    }
+  }
+
+  @Test
+  public void testTxn() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+
+    // put a key in root namespace, assert that it cannot be seen using kvClient with namespace
+    ByteSequence cmpKey = getNonexistentKey();
+    putKVWithAssertion(kvClient, cmpKey, TestUtil.randomByteSequence(), null);
+
+    ByteSequence key1 = getNonexistentKey();
+    ByteSequence value1 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key1, value1, null);
+
+    ByteSequence key2 = getNonexistentKey();
+    ByteSequence value2 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key2, value2, null);
+
+    // test comparison passes, with put operation.
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // cmpKey doesn't exist in this namespace
+          .If(new Cmp(cmpKey, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.put(key1, TestUtil.randomByteSequence(),
+              PutOption.newBuilder().withPrevKV().build()))
+          .Else(Op.put(key2, TestUtil.randomByteSequence(),
+              PutOption.newBuilder().withPrevKV().build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertThat(txnResponse.getPutResponses().size()).isEqualTo(1);
+      assertThat(txnResponse.getPutResponses().get(0).hasPrevKv()).isTrue();
+      assertThat(txnResponse.getPutResponses().get(0).getPrevKv().getKey()).isEqualTo(key1);
+      assertThat(txnResponse.getPutResponses().get(0).getPrevKv().getValue()).isEqualTo(value1);
+    }
+
+    // test comparison fails, with get operation.
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // key1 exists in this namespace
+          .If(new Cmp(key1, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.get(key1, GetOption.newBuilder().build()))
+          .Else(Op.get(key2, GetOption.newBuilder().build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertThat(txnResponse.getGetResponses().size()).isEqualTo(1);
+      assertThat(txnResponse.getGetResponses().get(0).getKvs().size()).isEqualTo(1);
+      assertThat(txnResponse.getGetResponses().get(0).getKvs().get(0).getKey()).isEqualTo(key2);
+      assertThat(txnResponse.getGetResponses().get(0).getKvs().get(0).getValue()).isEqualTo(value2);
+    }
+
+    // test delete operation
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          // key1 exists in this namespace
+          .If(new Cmp(key1, Cmp.Op.GREATER, CmpTarget.version(0)))
+          .Then(Op.delete(key2, DeleteOption.newBuilder().withPrevKV(true).build()))
+          .Else(Op.delete(key1, DeleteOption.newBuilder().withPrevKV(true).build()))
+          .commit();
+      TxnResponse txnResponse = txnFuture.get();
+      assertThat(txnResponse.getDeleteResponses().size()).isEqualTo(1);
+      assertThat(txnResponse.getDeleteResponses().get(0).getPrevKvs().size()).isEqualTo(1);
+      assertThat(txnResponse.getDeleteResponses().get(0).getPrevKvs().get(0).getKey())
+          .isEqualTo(key2);
+      assertThat(txnResponse.getDeleteResponses().get(0).getPrevKvs().get(0).getValue())
+          .isEqualTo(value2);
+    }
+  }
+
+  @Test
+  public void testNestedTxn() throws Exception {
+    // kvClient without namespace used as the judge for the final result
+    kvClient = Client.builder().endpoints(CLUSTER.getClientEndpoints()).build().getKVClient();
+    // kvClient with one namespace used to test operations with namespace
+    ByteSequence namespace = ByteSequence.from(TestUtil.randomByteSequence().getByteString()
+        .concat(ByteSequence.NAMESPACE_DELIMITER.getByteString()));
+    kvClientWithNamespace = Client.builder().endpoints(CLUSTER.getClientEndpoints())
+        .namespace(namespace).build().getKVClient();
+
+    ByteSequence cmpKey1 = getNonexistentKey();
+    putKVWithAssertion(kvClient, cmpKey1, TestUtil.randomByteSequence(), null);
+
+    ByteSequence cmpKey2 = getNonexistentKey();
+    putKVWithAssertion(kvClientWithNamespace, cmpKey2, TestUtil.randomByteSequence(), null);
+
+    ByteSequence key1 = getNonexistentKey();
+    ByteSequence value1 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key1, value1, null);
+
+    ByteSequence key2 = getNonexistentKey();
+    ByteSequence value2 = TestUtil.randomByteSequence();
+    putKVWithAssertion(kvClientWithNamespace, key2, value2, null);
+
+    {
+      Txn txn = kvClientWithNamespace.txn();
+      ByteSequence nextValue1 = TestUtil.randomByteSequence();
+      CompletableFuture<TxnResponse> txnFuture = txn
+          .If(new Cmp(cmpKey1, Cmp.Op.EQUAL, CmpTarget.version(0)))
+          .Then(Op.txn(
+              new Cmp[] {new Cmp(cmpKey2, Cmp.Op.GREATER, CmpTarget.version(0))},
+              new Op[] {Op.put(key1, nextValue1,
+                  PutOption.newBuilder().withPrevKV().build())},
+              new Op[] {Op.put(key2, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())}
+          ))
+          .Else(Op.txn(
+              new Cmp[] {new Cmp(cmpKey2, Cmp.Op.GREATER, CmpTarget.version(0))},
+              new Op[] {Op.put(key2, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())},
+              new Op[] {Op.put(key1, TestUtil.randomByteSequence(),
+                  PutOption.newBuilder().withPrevKV().build())}
+          )).commit();
+      TxnResponse response = txnFuture.get();
+      assertThat(response.getTxnResponses().size()).isEqualTo(1);
+      assertThat(response.getTxnResponses().get(0).getPutResponses().size()).isEqualTo(1);
+      assertThat(response.getTxnResponses().get(0).getPutResponses().get(0).hasPrevKv()).isTrue();
+      assertThat(response.getTxnResponses().get(0).getPutResponses().get(0).getPrevKv().getKey())
+          .isEqualTo(key1);
+      assertThat(response.getTxnResponses().get(0).getPutResponses().get(0).getPrevKv().getValue())
+          .isEqualTo(value1);
+      value1 = nextValue1;
+      assertExistentKey(kvClient,
+          ByteSequence.from(namespace.getByteString().concat(key1.getByteString())), value1);
+    }
+  }
+
+  /********************************* Internal Test Utilities ******************************/
+
+  class TestKeyValue {
+    ByteSequence key;
+    ByteSequence value;
+
+    TestKeyValue(ByteSequence key, ByteSequence value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+
+  private static ByteSequence getNonexistentKey() {
+    synchronized (keyIndex) {
+      keyIndex++;
+      return ByteSequence.from("sample_key_" + String.format("%05d", keyIndex), Charsets.UTF_8);
+    }
+  }
+
+  private static void assertNonexistentKey(KV kvClient, ByteSequence key) throws Exception {
+    CompletableFuture<GetResponse> getFeature = kvClient.get(key);
+    GetResponse response = getFeature.get();
+    assertThat(response.getKvs().size()).isEqualTo(0);
+  }
+
+  private static void assertExistentKey(KV kvClient, ByteSequence key, ByteSequence value)
+      throws Exception {
+    CompletableFuture<GetResponse> getFeature = kvClient.get(key);
+    GetResponse response = getFeature.get();
+    assertThat(response.getKvs().size()).isEqualTo(1);
+    assertThat(response.getKvs().get(0).getKey()).isEqualTo(key);
+    assertThat(response.getKvs().get(0).getValue()).isEqualTo(value);
+  }
+
+  /**
+   * Put key-value pair and return whether has previous KV.
+   */
+  private static boolean putKVWithAssertion(
+      KV kvClient, ByteSequence key, ByteSequence value, ByteSequence prevValue) throws Exception {
+    CompletableFuture<PutResponse> feature = kvClient.put(key, value,
+        PutOption.newBuilder().withPrevKV().build());
+    PutResponse response = feature.get();
+    if (prevValue != null) {
+      assertThat(response.hasPrevKv()).isTrue();
+      assertThat(response.getPrevKv().getKey()).isEqualTo(key);
+      assertThat(response.getPrevKv().getValue()).isEqualTo(prevValue);
+    }
+    return response.hasPrevKv();
+  }
+
+  private static void deleteKVWithAssertion(KV kvClient, ByteSequence key, ByteSequence prevValue)
+      throws Exception {
+    CompletableFuture<DeleteResponse> deleteFuture = kvClient.delete(key,
+        DeleteOption.newBuilder().withPrevKV(true).build());
+    DeleteResponse deleteResponse = deleteFuture.get();
+    assertThat(deleteResponse.getDeleted()).isEqualTo(1);
+    assertThat(deleteResponse.getPrevKvs().size()).isEqualTo(1);
+    assertThat(deleteResponse.getPrevKvs().get(0).getKey()).isEqualTo(key);
+    assertThat(deleteResponse.getPrevKvs().get(0).getValue()).isEqualTo(prevValue);
+    assertNonexistentKey(kvClient, key);
+  }
+
+  private static void putKVsWithAssertion(KV kvClient, List<TestKeyValue> keyValues)
+      throws Exception {
+    for (TestKeyValue keyValue : keyValues) {
+      putKVWithAssertion(kvClient, keyValue.key, keyValue.value, null);
+    }
+  }
+
+  private static void assertExistentKVs(KV kvClient, ByteSequence key, ByteSequence end,
+      List<TestKeyValue> expectedKVs) throws Exception {
+    CompletableFuture<GetResponse> getFuture = kvClient.get(key, GetOption.newBuilder()
+        .withRange(end).build());
+    GetResponse getResponse = getFuture.get();
+    assertThat(getResponse.getKvs().size()).isEqualTo(expectedKVs.size());
+    for (KeyValue keyValue : getResponse.getKvs()) {
+      boolean exist = false;
+      for (TestKeyValue expectedKV : expectedKVs) {
+        if (expectedKV.key.equals(keyValue.getKey())) {
+          exist = true;
+          assertThat(keyValue.getValue()).isEqualTo(expectedKV.value);
+          break;
+        }
+      }
+      assertThat(exist).isTrue();
+    }
+  }
+
+  private static void deleteKVsWithAssertion(KV kvClient, ByteSequence key, ByteSequence end,
+      List<TestKeyValue> previousKVs) throws Exception {
+    CompletableFuture<DeleteResponse> deleteFuture = kvClient.delete(key,
+        DeleteOption.newBuilder().withRange(end).withPrevKV(true).build());
+    DeleteResponse deleteResponse = deleteFuture.get();
+    assertThat(deleteResponse.getDeleted()).isEqualTo(previousKVs.size());
+    assertThat(deleteResponse.getPrevKvs().size()).isEqualTo(previousKVs.size());
+    for (KeyValue keyValue : deleteResponse.getPrevKvs()) {
+      boolean exist = false;
+      for (TestKeyValue previousKV : previousKVs) {
+        if (previousKV.key.equals(keyValue.getKey())) {
+          exist = true;
+          assertThat(keyValue.getValue()).isEqualTo(previousKV.value);
+          break;
+        }
+      }
+      assertThat(exist).isTrue();
+    }
+  }
+}

--- a/jetcd-core/src/test/java/io/etcd/jetcd/TxnResponseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/TxnResponseTest.java
@@ -40,7 +40,7 @@ public class TxnResponseTest {
             .setResponseRange(RangeResponse.getDefaultInstance()))
         .addResponses(ResponseOp.newBuilder().setResponseTxn(io.etcd.jetcd.api.TxnResponse.getDefaultInstance()))
         .build();
-    txnResponse = new TxnResponse(response);
+    txnResponse = new TxnResponse(response, ByteSequence.EMPTY);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <mockito.version>2.24.0</mockito.version>
         <assertj.version>3.11.1</assertj.version>
         <junit.version>4.12</junit.version>
+        <junit-jupiter.version>5.2.0</junit-jupiter.version>
         <netty-tcnative.version>2.0.20.Final</netty-tcnative.version>
         <testcontainers.version>1.10.6</testcontainers.version>
         <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
This enables users to specify a namespace when building a jetcd client.

Fixes #472