### PR TITLE
Fail tests immediately if etcd container failed to start

### DIFF
--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
@@ -51,6 +51,8 @@ public class EtcdContainer implements AutoCloseable {
   interface LifecycleListener {
     void started(EtcdContainer container);
 
+    void failedToStart(EtcdContainer container, Exception exception);
+
     void stopped(EtcdContainer container);
   }
 
@@ -142,12 +144,16 @@ public class EtcdContainer implements AutoCloseable {
     LOGGER.debug("starting etcd container {} with command: {}",
             endpoint, String.join(" ", container.getCommandParts()));
 
-    this.container.start();
-    this.listener.started(this);
+    try {
+      this.container.start();
+      this.listener.started(this);
 
-    if (dataDirectory != null) {
-      // needed in order to properly clean resources during shutdown
-      setDataDirectoryPermissions("o+rwx");
+      if (dataDirectory != null) {
+        // needed in order to properly clean resources during shutdown
+        setDataDirectoryPermissions("o+rwx");
+      }
+    } catch (Exception exception) {
+      this.listener.failedToStart(this, exception);
     }
   }
 


### PR DESCRIPTION
jetcd-launcher: fail test immediately if `EtcdClusterReosurce` failed to start.

Currently if etcd container fails to start test would be running for a minute until countdown latch won't expire: https://github.com/etcd-io/jetcd/blob/12ad75339701ed21816b99878088c9f13ec3b74a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterFactory.java#L63

Fixes #535 