### PR TITLE
jetcd-core: remove testNG, introduce "bytesOf"

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -69,11 +69,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
@@ -15,10 +15,10 @@
  */
 package io.etcd.jetcd;
 
+import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.common.base.Charsets;
 import io.grpc.netty.NettyChannelBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,10 +75,8 @@ public class ClientBuilderTest {
     return Stream.of(
         // namespace setting, expected namespace
         Arguments.of(ByteSequence.EMPTY, ByteSequence.EMPTY),
-        Arguments.of(ByteSequence.from("/namespace1/", Charsets.UTF_8),
-            ByteSequence.from("/namespace1/", Charsets.UTF_8)),
-        Arguments.of(ByteSequence.from("namespace2/", Charsets.UTF_8),
-            ByteSequence.from("namespace2/", Charsets.UTF_8))
+        Arguments.of(bytesOf("/namespace1/"), bytesOf("/namespace1/")),
+        Arguments.of(bytesOf("namespace2/"), bytesOf("namespace2/"))
     );
   }
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientConnectionManagerTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientConnectionManagerTest.java
@@ -15,10 +15,9 @@
  */
 package io.etcd.jetcd;
 
-
+import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Charsets;
 import io.etcd.jetcd.kv.PutResponse;
 import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import io.grpc.CallOptions;
@@ -64,7 +63,7 @@ public class ClientConnectionManagerTest {
       });
 
     try (Client client = builder.build()) {
-      CompletableFuture<PutResponse> future = client.getKVClient().put(ByteSequence.from("sample_key", Charsets.UTF_8), ByteSequence.from("sample_key", Charsets.UTF_8));
+      CompletableFuture<PutResponse> future = client.getKVClient().put(bytesOf("sample_key"), bytesOf("sample_key"));
       latch.await(1, TimeUnit.MINUTES);
       future.get();
     }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
@@ -15,7 +15,6 @@
  */
 package io.etcd.jetcd;
 
-import com.google.common.base.Charsets;
 import com.google.protobuf.ByteString;
 import io.etcd.jetcd.kv.DeleteResponse;
 import io.etcd.jetcd.kv.GetResponse;
@@ -43,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
+import static io.etcd.jetcd.TestUtil.byteStringOf;
+import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -90,29 +91,29 @@ public class KVNamespaceTest {
         // namespace, key, end, wKey, wEnd
         // 1. single key
         Arguments.of(
-            ByteSequence.from("pfx/", Charsets.UTF_8),
-            ByteString.copyFrom("a".getBytes(Charsets.UTF_8)),
+            bytesOf("pfx/"),
+            byteStringOf("a"),
             null,
-            ByteString.copyFrom("pfx/a".getBytes(Charsets.UTF_8)),
+            byteStringOf("pfx/a"),
             null),
         // 2. range
         Arguments.of(
-            ByteSequence.from("pfx/", Charsets.UTF_8),
-            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
-            ByteString.copyFrom("def".getBytes(Charsets.UTF_8)),
-            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
-            ByteString.copyFrom("pfx/def".getBytes(Charsets.UTF_8))),
+            bytesOf("pfx/"),
+            byteStringOf("abc"),
+            byteStringOf("def"),
+            byteStringOf("pfx/abc"),
+            byteStringOf("pfx/def")),
         // 3. one-sided range
         Arguments.of(
-            ByteSequence.from("pfx/", Charsets.UTF_8),
-            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            bytesOf("pfx/"),
+            byteStringOf("abc"),
             ByteString.copyFrom(new byte[] {0}),
-            ByteString.copyFrom("pfx/abc".getBytes(Charsets.UTF_8)),
-            ByteString.copyFrom("pfx0".getBytes(Charsets.UTF_8))),
+            byteStringOf("pfx/abc"),
+            byteStringOf("pfx0")),
         // 4. one-sided range, end of key space
         Arguments.of(
             ByteSequence.from(new byte[] {(byte) 0xff, (byte) 0xff}),
-            ByteString.copyFrom("abc".getBytes(Charsets.UTF_8)),
+            byteStringOf("abc"),
             ByteString.copyFrom(new byte[] {0}),
             ByteString.copyFrom(new byte[] {(byte) 0xff, (byte) 0xff, 'a', 'b', 'c'}),
             ByteString.copyFrom(new byte[] {0}))
@@ -398,7 +399,7 @@ public class KVNamespaceTest {
   private static ByteSequence getNonexistentKey() {
     synchronized (keyIndex) {
       keyIndex++;
-      return ByteSequence.from("sample_key_" + String.format("%05d", keyIndex), Charsets.UTF_8);
+      return bytesOf("sample_key_" + String.format("%05d", keyIndex));
     }
   }
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
@@ -18,8 +18,7 @@ package io.etcd.jetcd;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Charsets;
-import io.etcd.jetcd.launcher.EtcdCluster;
-import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
 import io.etcd.jetcd.lease.LeaseTimeToLiveResponse;
 import io.etcd.jetcd.options.LeaseOption;
@@ -30,16 +29,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
  * Lease service test cases.
  */
 public class LeaseTest {
-  private static EtcdCluster cluster;
+  @ClassRule
+  public static EtcdClusterResource clusterResource = new EtcdClusterResource("etcd-lease", 3 ,false);
 
   private KV kvClient;
   private Client client;
@@ -49,22 +48,10 @@ public class LeaseTest {
   private static final ByteSequence KEY_2 = ByteSequence.from("foo2", Charsets.UTF_8);
   private static final ByteSequence VALUE = ByteSequence.from("bar", Charsets.UTF_8);
 
-  @BeforeClass
-  public static void beforeClass() {
-    cluster = EtcdClusterFactory.buildCluster("etcd-lease", 3 ,false);
-    cluster.start();
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    cluster.close();
-  }
 
   @Before
   public void setUp() {
-    cluster.start();
-
-    client = Client.builder().endpoints(cluster.getClientEndpoints()).build();
+    client = Client.builder().endpoints(clusterResource.cluster().getClientEndpoints()).build();
     kvClient = client.getKVClient();
     leaseClient = client.getLeaseClient();
   }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceTest.java
@@ -18,8 +18,7 @@ package io.etcd.jetcd;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-import io.etcd.jetcd.launcher.EtcdCluster;
-import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import io.etcd.jetcd.maintenance.SnapshotResponse;
 import io.etcd.jetcd.maintenance.StatusResponse;
 import io.grpc.stub.StreamObserver;
@@ -36,9 +35,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -47,7 +45,8 @@ import org.junit.rules.TemporaryFolder;
  * Maintenance test.
  */
 public class MaintenanceTest {
-  private static EtcdCluster cluster;
+  @ClassRule
+  public static EtcdClusterResource clusterResource = new EtcdClusterResource("etcd-maintenance", 3 ,false);
 
   private Client client;
   private Maintenance maintenance;
@@ -56,21 +55,9 @@ public class MaintenanceTest {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @BeforeClass
-  public static void beforeClass() {
-    cluster = EtcdClusterFactory.buildCluster("etcd-maintenance", 3 ,false);
-    cluster.start();
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    cluster.close();
-  }
-
-
   @Before
   public void setUp() {
-    this.endpoints = cluster.getClientEndpoints();
+    this.endpoints = clusterResource.cluster().getClientEndpoints();
     this.client = Client.builder().endpoints(endpoints).build();
     this.maintenance = client.getMaintenanceClient();
   }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/TestUtil.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/TestUtil.java
@@ -15,12 +15,24 @@
  */
 package io.etcd.jetcd;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
 
 public class TestUtil {
+
+  public static ByteSequence bytesOf(final String string) {
+    return ByteSequence.from(string, UTF_8);
+  }
+
+  public static ByteString byteStringOf(final String string) {
+    return ByteString.copyFrom(string.getBytes(UTF_8));
+  }
 
   public static String randomString() {
     return java.util.UUID.randomUUID().toString();

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
@@ -15,9 +15,9 @@
  */
 package io.etcd.jetcd;
 
+import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Charsets;
 import io.etcd.jetcd.Watch.Watcher;
 import io.etcd.jetcd.common.exception.CompactedException;
 import io.etcd.jetcd.kv.PutResponse;
@@ -49,7 +49,7 @@ import org.junit.runners.Parameterized;
 public class WatchTest {
   @ClassRule
   public static final EtcdClusterResource clusterResource = new EtcdClusterResource("watch", 3);
-  private static final ByteSequence namespace = ByteSequence.from("test-namespace/", Charsets.UTF_8);
+  private static final ByteSequence namespace = bytesOf("test-namespace/");
 
   private static Client client;
   private static Client clientWithNamespace;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
@@ -15,7 +15,7 @@
  */
 package io.etcd.jetcd;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -59,7 +59,7 @@ import org.mockito.junit.MockitoRule;
  */
 public class WatchUnitTest {
 
-  private final static ByteSequence KEY = ByteSequence.from("test_key", UTF_8);
+  private final static ByteSequence KEY = bytesOf("test_key");
   @Rule
   public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();
   @Rule


### PR DESCRIPTION
TestNG is removed to unify stack used for testing, `ByteSequence.from(<str>, UTF_8)` is replaced with more concise `bytesOf(<str>)`

Fixes #309