### PR TITLE
all: update copyrights and configure license plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ This is a rough outline of what a contributor's workflow looks like:
 
 - Create a topic branch from where to base the contribution. This is usually master.
 - Make commits of logical units.
+- Run `license:format` to make sure license headers are properly formatted (see below).
 - Make sure commit messages are in the proper format (see below).
 - Push changes in a topic branch to a personal fork of the repository.
 - Submit a pull request to etcd-io/jetcd.
@@ -33,6 +34,16 @@ Thanks for contributing!
 The coding style follows Google Java Style. See the [style doc](https://google.github.io/styleguide/javaguide.html) for details.
 
 Please follow this style to make jetcd easy to review, maintain, and develop.
+
+### License headers
+
+To make sure CI checks would pass please run
+
+```bash
+./mvnw license:format
+```
+
+and including any changes in PR before opening it.
 
 ### Format of the commit message
 

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/etc/license-formatting.xml
+++ b/etc/license-formatting.xml
@@ -16,21 +16,15 @@
     limitations under the License.
 
 -->
-<lifecycleMappingMetadata>
-  <pluginExecutions>
-    <pluginExecution>
-      <pluginExecutionFilter>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>${project.artifactId}</artifactId>
-        <versionRange>${project.version}</versionRange>
-        <goals>
-          <goal>start</goal>
-          <goal>stop</goal>
-        </goals>
-      </pluginExecutionFilter>
-      <action>
-        <ignore />
-      </action>
-    </pluginExecution>
-  </pluginExecutions>
-</lifecycleMappingMetadata>
+<additionalHeaders>
+    <SLASHSTART_WITH_BLANKLINE_STYLE>
+        <firstLine><![CDATA[/*]]></firstLine>
+        <beforeEachLine><![CDATA[ * ]]></beforeEachLine>
+        <endLine><![CDATA[ */EOL]]></endLine>
+        <firstLineDetectionPattern><![CDATA[(EOL)*(\s|\t)*/\*.*$]]></firstLineDetectionPattern>
+        <lastLineDetectionPattern><![CDATA[.*\*/(\s|\t)*$]]></lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </SLASHSTART_WITH_BLANKLINE_STYLE>
+</additionalHeaders>

--- a/etc/license.txt
+++ b/etc/license.txt
@@ -1,4 +1,4 @@
-Copyright 2017 The jetcd authors
+Copyright ${license.git.copyrightYears} The jetcd authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/etc/mvn-deploy-settings.xml
+++ b/etc/mvn-deploy-settings.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,7 +16,6 @@
     limitations under the License.
 
 -->
-
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="

--- a/etc/versions-rules.xml
+++ b/etc/versions-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-all/pom.xml
+++ b/jetcd-all/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-all/src/main/java/io/etcd/jetcd/all/JetcdAll.java
+++ b/jetcd-all/src/main/java/io/etcd/jetcd/all/JetcdAll.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-all/src/main/java/io/etcd/jetcd/all/package-info.java
+++ b/jetcd-all/src/main/java/io/etcd/jetcd/all/package-info.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/pom.xml
+++ b/jetcd-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedClientException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedClientException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedKeepAliveListenerException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedKeepAliveListenerException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedSnapshotException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedSnapshotException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedWatcherException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/ClosedWatcherException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/CompactedException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/CompactedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdExceptionFactory.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdExceptionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/AbstractResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/AbstractResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Auth.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Auth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/AuthImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/AuthImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Client.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Client.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/CloseableClient.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/CloseableClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Cluster.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Cluster.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClusterImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClusterImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Constants.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Constants.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KV.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KV.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KVImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/KeyValue.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Lease.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Lease.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/LeaseImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/LeaseImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Lock.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Lock.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/LockImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/LockImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Maintenance.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Maintenance.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/MaintenanceImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/MaintenanceImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Observers.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Observers.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Response.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Response.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Txn.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Txn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthDisableResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthDisableResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthEnableResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthEnableResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleAddResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleAddResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleDeleteResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleDeleteResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleGetResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleGetResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleGrantPermissionResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleGrantPermissionResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleListResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleListResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleRevokePermissionResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthRoleRevokePermissionResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserAddResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserAddResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserChangePasswordResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserChangePasswordResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserDeleteResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserDeleteResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserGetResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserGetResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserGrantRoleResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserGrantRoleResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserListResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserListResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserRevokeRoleResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/AuthUserRevokeRoleResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/auth/Permission.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/auth/Permission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/Member.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/Member.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberAddResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberAddResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberListResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberListResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberRemoveResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberRemoveResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberUpdateResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/MemberUpdateResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/cluster/Util.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/cluster/Util.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/CompactResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/CompactResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/DeleteResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/GetResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/PutResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/kv/TxnResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseGrantResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseGrantResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseKeepAliveResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseKeepAliveResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseKeepAliveResponseWithError.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseKeepAliveResponseWithError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseRevokeResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseRevokeResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseTimeToLiveResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/LeaseTimeToLiveResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lease/NoSuchLeaseException.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lease/NoSuchLeaseException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lock/LockResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/lock/UnlockResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/lock/UnlockResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmMember.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmMember.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmType.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/AlarmType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/DefragmentResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/DefragmentResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/HashKVResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/HashKVResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/MoveLeaderResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/MoveLeaderResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/SnapshotReaderResponseWithError.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/SnapshotReaderResponseWithError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/SnapshotResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/SnapshotResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/CmpTarget.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/CmpTarget.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Op.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/TxnImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/TxnImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/CompactOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/CompactOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/DeleteOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/DeleteOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/GetOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/GetOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/LeaseOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/LeaseOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/OptionsUtil.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/OptionsUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/PutOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/PutOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchEvent.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchEvent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponseWithError.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponseWithError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/proto/auth.proto
+++ b/jetcd-core/src/main/proto/auth.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 The jetcd authors
+// Copyright 2016-2019 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/proto/kv.proto
+++ b/jetcd-core/src/main/proto/kv.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 The jetcd authors
+// Copyright 2016-2019 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/proto/lock.proto
+++ b/jetcd-core/src/main/proto/lock.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 The jetcd authors
+// Copyright 2016-2019 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/proto/rpc.proto
+++ b/jetcd-core/src/main/proto/rpc.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 The jetcd authors
+// Copyright 2016-2019 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/jetcd-core/src/test/java/io/etcd/jetcd/AuthClientTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/AuthClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientConnectionManagerTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientConnectionManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClusterClientTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClusterClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/KVNamespaceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import com.google.protobuf.ByteString;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/KVTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/KVTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static com.google.common.base.Charsets.UTF_8;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LeaseUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LeaseUnitTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.toEtcdException;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LoadBalancerTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LoadBalancerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/LockTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LockTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import com.google.common.base.Charsets;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceUnitTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/SslTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/SslTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/TestUtil.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/TestUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/TxnResponseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/TxnResponseTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchResumeTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchResumeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/java/io/etcd/jetcd/op/TxnTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/op/TxnTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd.op;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;

--- a/jetcd-core/src/test/resources/log4j2.xml
+++ b/jetcd-core/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/pom.xml
+++ b/jetcd-examples/jetcd-ctl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandGet.java
+++ b/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandGet.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandPut.java
+++ b/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandPut.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandWatch.java
+++ b/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandWatch.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/Main.java
+++ b/jetcd-examples/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/Main.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-ctl/src/main/resources/log4j2.xml
+++ b/jetcd-examples/jetcd-ctl/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-watch/pom.xml
+++ b/jetcd-examples/jetcd-watch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-watch/src/main/java/io/etcd/jetcd/examples/watch/Main.java
+++ b/jetcd-examples/jetcd-watch/src/main/java/io/etcd/jetcd/examples/watch/Main.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-examples/jetcd-watch/src/main/resources/log4j2.xml
+++ b/jetcd-examples/jetcd-watch/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-examples/pom.xml
+++ b/jetcd-examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-extensions/pom.xml
+++ b/jetcd-extensions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-extensions/src/main/java/io/etcd/jetcd/extensions/Extensions.java
+++ b/jetcd-extensions/src/main/java/io/etcd/jetcd/extensions/Extensions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin-test/pom.xml
+++ b/jetcd-launcher-maven-plugin-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin-test/src/test/java/io/etcd/jetcd/launcher/maven/test/MavenPluginTest.java
+++ b/jetcd-launcher-maven-plugin-test/src/test/java/io/etcd/jetcd/launcher/maven/test/MavenPluginTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin/pom.xml
+++ b/jetcd-launcher-maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/Singleton.java
+++ b/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/Singleton.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/StartMojo.java
+++ b/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/StartMojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/StopMojo.java
+++ b/jetcd-launcher-maven-plugin/src/main/java/io/etcd/jetcd/launcher/maven/StopMojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher/pom.xml
+++ b/jetcd-launcher/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdCluster.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdCluster.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterFactory.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit4/EtcdClusterResource.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit4/EtcdClusterResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit5/EtcdClusterExtension.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/junit5/EtcdClusterExtension.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/pom.xml
+++ b/jetcd-osgi/jetcd-karaf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/src/main/java/io/etcd/jetcd/karaf/package-info.java
+++ b/jetcd-osgi/jetcd-karaf/src/main/java/io/etcd/jetcd/karaf/package-info.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/src/main/resources/features.xml
+++ b/jetcd-osgi/jetcd-karaf/src/main/resources/features.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/ClientServiceChecks.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/ClientServiceChecks.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/PaxExamWrapperTest.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/PaxExamWrapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/TestSupport.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/TestSupport.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-osgi/pom.xml
+++ b/jetcd-osgi/jetcd-osgi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/ClientService.java
+++ b/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/ClientService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/DnsSrvResolverService.java
+++ b/jetcd-osgi/jetcd-osgi/src/main/java/io/etcd/jetcd/osgi/DnsSrvResolverService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-osgi/pom.xml
+++ b/jetcd-osgi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-resolver-dns-srv/pom.xml
+++ b/jetcd-resolver-dns-srv/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-resolver-dns-srv/src/main/java/io/etcd/jetcd/resolver/dnssrv/DnsSrvUriResolver.java
+++ b/jetcd-resolver-dns-srv/src/main/java/io/etcd/jetcd/resolver/dnssrv/DnsSrvUriResolver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver-dns-srv/src/test/java/io/etcd/jetcd/resolver/dnssrv/NameResolverTest.java
+++ b/jetcd-resolver-dns-srv/src/test/java/io/etcd/jetcd/resolver/dnssrv/NameResolverTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd.resolver.dnssrv;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jetcd-resolver-dns-srv/src/test/resources/log4j2.xml
+++ b/jetcd-resolver-dns-srv/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-resolver/pom.xml
+++ b/jetcd-resolver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/DirectUriResolver.java
+++ b/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/DirectUriResolver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/SmartNameResolver.java
+++ b/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/SmartNameResolver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/SmartNameResolverFactory.java
+++ b/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/SmartNameResolverFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/URIResolver.java
+++ b/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/URIResolver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/URIResolverLoader.java
+++ b/jetcd-resolver/src/main/java/io/etcd/jetcd/resolver/URIResolverLoader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jetcd-resolver/src/test/java/io/etcd/jetcd/resolver/NameResolverTest.java
+++ b/jetcd-resolver/src/test/java/io/etcd/jetcd/resolver/NameResolverTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 The jetcd authors
+/*
+ * Copyright 2016-2019 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.etcd.jetcd.resolver;
 
 import io.etcd.jetcd.common.exception.EtcdException;

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The jetcd authors
+    Copyright 2016-2019 The jetcd authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -708,6 +708,9 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <version>${license-maven-plugin.version}</version>
                 <configuration>
+                    <properties>
+                        <project.inceptionYear>2016</project.inceptionYear>
+                    </properties>
                     <header>${jetcd.project.root}/etc/license.txt</header>
                     <excludes>
                         <exclude>**/ErrorCode.java</exclude>
@@ -729,10 +732,22 @@
                         <exclude>target-ide/**</exclude>
                         <exclude>.factorypath</exclude>
                     </excludes>
+                    <headerDefinitions>
+                        <headerDefinition>${jetcd.project.root}/etc/license-formatting.xml</headerDefinition>
+                    </headerDefinitions>
                     <mapping>
                         <proto>DOUBLESLASH_STYLE</proto>
+                        <java>SLASHSTART_WITH_BLANKLINE_STYLE</java>
                     </mapping>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin-git</artifactId>
+                        <!-- make sure you use the same version as license-maven-plugin -->
+                        <version>${license-maven-plugin.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Update copyrights to include current year and also configure license plugin to work with current year.

Changes:
 * License plugin configured to use [`license.git.copyrightLastYear`](https://github.com/mycila/license-maven-plugin/tree/master/license-maven-plugin-git)
 * Comment style is changed from javadoc (`/** ... */`) to slash start (`/* ... */`) with additional blank line after it.
   * Slashstar (`/* ... */`) because IDE tends to include `<p>` when autoformat is executed which is annoying (also see discussion about license formatting here: https://github.com/mycila/license-maven-plugin/pull/115)
   * Additional blank line is needed for checkstyle. Had to create custom header definition since property to add blank line after header is not yet supported (https://github.com/mycila/license-maven-plugin/issues/78)
 * `CONTRIBUTING.md` updated with instructions on how to run license formatting

Fixes #515 