### PR TITLE
cmp.Op: Add NOT_EQUAL operator

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/Cmp.java
@@ -27,7 +27,7 @@ import io.etcd.jetcd.api.Compare;
 public class Cmp {
 
   public enum Op {
-    EQUAL, GREATER, LESS
+    EQUAL, GREATER, LESS, NOT_EQUAL
   }
 
   private final ByteString key;
@@ -52,6 +52,9 @@ public class Cmp {
         break;
       case LESS:
         compareBuilder.setResult(Compare.CompareResult.LESS);
+        break;
+      case NOT_EQUAL:
+        compareBuilder.setResult(Compare.CompareResult.NOT_EQUAL);
         break;
       default:
         throw new IllegalArgumentException("Unexpected compare type (" + this.op + ")");


### PR DESCRIPTION
adds the NOT_EQUAL operator, which is defined in the proto.

Fixes #558