### PR TITLE
Build(shade): fix shade to include gRPC META-INF

### DIFF
--- a/jetcd-all/pom.xml
+++ b/jetcd-all/pom.xml
@@ -125,6 +125,9 @@
                                     </shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/ClientServiceChecks.java
+++ b/jetcd-osgi/jetcd-karaf/src/test/java/io/etcd/jetcd/osgi/ClientServiceChecks.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -126,7 +125,6 @@ public class ClientServiceChecks extends TestSupport {
     };
   }
 
-  @Ignore("https://github.com/grpc/grpc-java/issues/6020")
   @Test
   public void testServiceAvailability() throws Exception {
     assertThat(bundleContext).isNotNull();

--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,18 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>${maven-shade-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <transformers>
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                </transformers>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <!--


### PR DESCRIPTION
Removes `@Ignore` from affected test
Add ServicesResourceTransformer to shaded plugin in parent `pom.xml` and `jetcd-all/pom.xml`.