### PR TITLE
modify grpc-netty dependency as grpc-netty-shaded

### DIFF
--- a/jetcd-core/pom.xml
+++ b/jetcd-core/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -20,13 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import io.etcd.jetcd.common.exception.EtcdException;
-import io.etcd.jetcd.common.exception.EtcdExceptionFactory;
-import io.etcd.jetcd.resolver.URIResolverLoader;
-import io.grpc.ClientInterceptor;
-import io.grpc.Metadata;
-import io.grpc.netty.GrpcSslContexts;
-import io.netty.handler.ssl.SslContext;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +31,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+
+import io.etcd.jetcd.common.exception.EtcdException;
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory;
+import io.etcd.jetcd.resolver.URIResolverLoader;
+import io.grpc.ClientInterceptor;
+import io.grpc.Metadata;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 
 /**
  * ClientBuilder knows how to create an Client instance.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -22,9 +22,22 @@ import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.handleInterrup
 import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.toEtcdException;
 import static io.etcd.jetcd.resolver.SmartNameResolverFactory.forEndpoints;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
+
 import io.etcd.jetcd.api.AuthGrpc;
 import io.etcd.jetcd.api.AuthenticateRequest;
 import io.etcd.jetcd.api.AuthenticateResponse;
@@ -41,19 +54,9 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NegotiationType;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.AbstractStub;
-import java.net.URI;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-import javax.annotation.Nonnull;
 
 final class ClientConnectionManager {
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/ClientBuilderTest.java
@@ -20,15 +20,17 @@ import static io.etcd.jetcd.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.grpc.netty.NettyChannelBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Random;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 
 public class ClientBuilderTest {
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/MaintenanceUnitTest.java
@@ -20,16 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
 
-import com.google.protobuf.ByteString;
-import io.etcd.jetcd.api.MaintenanceGrpc.MaintenanceImplBase;
-import io.etcd.jetcd.api.SnapshotRequest;
-import io.etcd.jetcd.api.SnapshotResponse;
-import io.etcd.jetcd.common.exception.EtcdException;
-import io.grpc.Server;
-import io.grpc.Status;
-import io.grpc.netty.NettyServerBuilder;
-import io.grpc.stub.StreamObserver;
-import io.grpc.util.MutableHandlerRegistry;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -40,10 +30,23 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.ByteString;
+
+import io.etcd.jetcd.api.MaintenanceGrpc.MaintenanceImplBase;
+import io.etcd.jetcd.api.SnapshotRequest;
+import io.etcd.jetcd.api.SnapshotResponse;
+import io.etcd.jetcd.common.exception.EtcdException;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.util.MutableHandlerRegistry;
 
 // TODO: have separate folders to unit and integration tests.
 // TODO(#548): Add global timeout for tests once JUnit5 supports it

--- a/jetcd-core/src/test/java/io/etcd/jetcd/SslTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/SslTest.java
@@ -17,10 +17,7 @@
 package io.etcd.jetcd;
 
 import static io.etcd.jetcd.TestUtil.bytesOf;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-
-import io.etcd.jetcd.launcher.junit5.EtcdClusterExtension;
-import io.grpc.netty.GrpcSslContexts;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,6 +27,9 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.etcd.jetcd.launcher.junit5.EtcdClusterExtension;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 
 // TODO(#548): Add global timeout for tests once JUnit5 supports it
 public class SslTest {

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
             </dependency>
             <dependency>
                 <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty</artifactId>
+                <artifactId>grpc-netty-shaded</artifactId>
                 <version>${grpc.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
change the pom.xml dependency of 'jetc-core' module and the java import package, make it dependent on grpc-netty-shaded to reduce netty library exposure.