### PR TITLE
Change private subclasses of CmpTarget to public subclasses

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/CmpTarget.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/CmpTarget.java
@@ -91,28 +91,28 @@ public abstract class CmpTarget<T> {
     return targetValue;
   }
 
-  private static final class VersionCmpTarget extends CmpTarget<Long> {
+  public static final class VersionCmpTarget extends CmpTarget<Long> {
 
     VersionCmpTarget(Long targetValue) {
       super(Compare.CompareTarget.VERSION, targetValue);
     }
   }
 
-  private static final class CreateRevisionCmpTarget extends CmpTarget<Long> {
+  public static final class CreateRevisionCmpTarget extends CmpTarget<Long> {
 
     CreateRevisionCmpTarget(Long targetValue) {
       super(Compare.CompareTarget.CREATE, targetValue);
     }
   }
 
-  private static final class ModRevisionCmpTarget extends CmpTarget<Long> {
+  public static final class ModRevisionCmpTarget extends CmpTarget<Long> {
 
     ModRevisionCmpTarget(Long targetValue) {
       super(Compare.CompareTarget.MOD, targetValue);
     }
   }
 
-  private static final class ValueCmpTarget extends CmpTarget<ByteString> {
+  public static final class ValueCmpTarget extends CmpTarget<ByteString> {
 
     ValueCmpTarget(ByteString targetValue) {
       super(Compare.CompareTarget.VALUE, targetValue);


### PR DESCRIPTION
CmpTarget.value() returns a ValueCmpTarget value, which is a private static. This is okay in Java, but it does not work from Kotlin. If you call CmpTarget.value() from Kotlin you get the warning: "Type CmpTarget.ValueCmpTarget! is inaccessible in this context due to: private final class ValueCmpTarget : CmpTarget<ByteString> defined in io.etcd.jetcd.op.CmdTarget"