### PR TITLE
Fix EtcdClusterResource invocation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `io.etcd:jetcd-launcher` offers a convenient utility to programmatically sta
 
 ```java
 @Rule public final EtcdClusterResource etcd = new EtcdClusterResource("test-etcd", 1);
-Client client = Client.builder().endpoints(etcd.cluster().getClientEndpoints()).build();
+Client client = Client.builder().endpoints(etcd.getClientEndpoints()).build();
 ```
 
 This launcher uses the Testcontainers framework.


### PR DESCRIPTION
`EtcdClusterResource#cluster()` does not exist in current releases. This replaces the example code with the direct call to `#getClientEndpoints()`.