### PR TITLE
watch refresh access token

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -136,6 +136,12 @@ final class ClientConnectionManager {
         return token;
     }
 
+    void forceTokenRefresh() {
+        synchronized (lock) {
+            token = null;
+        }
+    }
+
     private void refreshToken(Channel channel) {
         synchronized (lock) {
             token = generateToken(channel);

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchTokenExpireTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchTokenExpireTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2020 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.jetcd;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.etcd.jetcd.auth.Permission;
+import io.etcd.jetcd.test.EtcdClusterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(value = 30)
+public class WatchTokenExpireTest {
+    // create a cluster with SSL enabled, because otherwise volumes with certificates are not mapped
+    // to test Docker container. setup JWT authentication provider, it allows to configure short
+    // time-to-live of the token.
+    @RegisterExtension
+    public static final EtcdClusterExtension cluster = new EtcdClusterExtension(
+        "etcd-ssl", 1, true, "--auth-token",
+        "jwt,pub-key=/etc/ssl/etcd/server.pem,priv-key=/etc/ssl/etcd/server-key.pem,sign-method=RS256,ttl=1s");
+
+    private static final ByteSequence key = TestUtil.randomByteSequence();
+    private static final ByteSequence user = TestUtil.bytesOf("root");
+    private static final ByteSequence password = TestUtil.randomByteSequence();
+
+    private void setUpEnvironment() throws Exception {
+        File caFile = new File(getClass().getResource("/ssl/cert/ca.pem").toURI());
+        Client client = Client.builder().endpoints(cluster.getClientEndpoints())
+            .authority("etcd0").sslContext(b -> b.trustManager(caFile)).build();
+
+        // enable authentication to enforce usage of access token
+        ByteSequence role = TestUtil.bytesOf("root");
+        client.getAuthClient().roleAdd(role).get();
+        client.getAuthClient().userAdd(user, password).get();
+        // grant access only to given key
+        client.getAuthClient().roleGrantPermission(role, key, key, Permission.Type.READWRITE).get();
+        client.getAuthClient().userGrantRole(user, role).get();
+        client.getAuthClient().authEnable().get();
+
+        client.close();
+    }
+
+    private Client createAuthClient() throws Exception {
+        File caFile = new File(getClass().getResource("/ssl/cert/ca.pem").toURI());
+        return Client.builder().endpoints(cluster.getClientEndpoints())
+            .user(user).password(password).authority("etcd0").sslContext(b -> b.trustManager(caFile)).build();
+    }
+
+    @Test
+    public void testRefreshExpiredToken() throws Exception {
+        setUpEnvironment();
+
+        Client authClient = createAuthClient();
+        Watch authWatchClient = authClient.getWatchClient();
+        KV authKVClient = authClient.getKVClient();
+
+        authKVClient.put(key, TestUtil.randomByteSequence()).get(1, TimeUnit.SECONDS);
+        Thread.sleep(3000);
+
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger modifications = new AtomicInteger();
+
+        // watch should handle token refresh automatically
+        // token is already expired when we attempt to create a watch
+        Watch.Watcher watcher = authWatchClient.watch(key, response -> {
+            modifications.incrementAndGet();
+            latch.countDown();
+        });
+
+        // create single thread pool, so that tasks are executed one after another
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        List<Future<?>> futures = new ArrayList<>(2);
+        Client anotherClient = createAuthClient();
+        for (int i = 0; i < 2; ++i) {
+            futures.add(executor.submit(() -> {
+                try {
+                    // wait 3 seconds for token to expire. during the test token will be refreshed twice
+                    Thread.sleep(3000);
+                    anotherClient.getKVClient().put(key, TestUtil.randomByteSequence()).get(1, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        assertThat(modifications.get()).isEqualTo(2);
+
+        executor.shutdownNow();
+        futures.forEach(f -> assertThat(f).isDone());
+
+        anotherClient.close();
+        watcher.close();
+        authWatchClient.close();
+        authClient.close();
+    }
+}

--- a/jetcd-launcher/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
+++ b/jetcd-launcher/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdContainer.java
@@ -46,7 +46,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class EtcdContainer implements AutoCloseable {
-    public static final String ETCD_DOCKER_IMAGE_NAME = "gcr.io/etcd-development/etcd:v3.3";
+    public static final String ETCD_DOCKER_IMAGE_NAME = "gcr.io/etcd-development/etcd:v3.4.5";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EtcdCluster.class);
     private static final int ETCD_CLIENT_PORT = 2379;

--- a/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
+++ b/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
@@ -45,6 +45,10 @@ public class EtcdClusterExtension implements EtcdCluster, BeforeAllCallback, Aft
         this.cluster = EtcdClusterFactory.buildCluster(clusterName, nodes, ssl);
     }
 
+    public EtcdClusterExtension(String clusterName, int nodes, boolean ssl, String... additionalArgs) {
+        this.cluster = EtcdClusterFactory.buildCluster(clusterName, nodes, ssl, additionalArgs);
+    }
+
     // Test framework methods
 
     @Override


### PR DESCRIPTION
Fix for issue #659. Watch hangs when we attempt to register it and access token is already expired. Test container version updated to support JWT TTL configuration.