### PR TITLE
fix the javadocs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![License](https://img.shields.io/badge/Licence-Apache%202.0-blue.svg?style=flat-square)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Maven Central](https://img.shields.io/maven-central/v/io.etcd/jetcd-core.svg?style=flat-square)](https://search.maven.org/#search%7Cga%7C1%7Cio.etcd)
 [![GitHub release](https://img.shields.io/github/release/etcd-io/jetcd.svg?style=flat-square)](https://github.com/etcd-io/jetcd/releases)
-[![Javadocs](http://www.javadoc.io/badge/io/etcd/jetcd-core.svg)](http://www.javadoc.io/doc/io/etcd/jetcd-core)
-
+[![Javadocs](http://www.javadoc.io/badge/io/etcd/jetcd-core.svg)](https://javadoc.io/doc/io.etcd/jetcd-core)
 
 jetcd is the official java client for [etcd](https://github.com/etcd-io/etcd) v3.
 


### PR DESCRIPTION
The current link redirects to javadoc.io with this error message: 
> Artifact io:etcd does not exist.