### PR TITLE
Add keepalive config for gRPC

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -65,6 +65,9 @@ public final class ClientBuilder implements Cloneable {
     private ByteSequence namespace = ByteSequence.EMPTY;
     private long retryDelay = 500;
     private long retryMaxDelay = 2500;
+    private Long keepaliveTimeMs;
+    private Long keepaliveTimeoutMs;
+    private Boolean keepaliveWithoutCalls;
     private ChronoUnit retryChronoUnit = ChronoUnit.MILLIS;
     private String retryMaxDuration;
 
@@ -425,6 +428,51 @@ public final class ClientBuilder implements Cloneable {
      */
     public ClientBuilder retryMaxDelay(long retryMaxDelay) {
         this.retryMaxDelay = retryMaxDelay;
+        return this;
+    }
+
+    public Long keepaliveTimeMs() {
+        return keepaliveTimeMs;
+    }
+
+    /**
+     * The interval for gRPC keepalives.
+     * The current minimum allowed by gRPC is 10s
+     * 
+     * @param keepaliveTimeMs time in ms between keepalives
+     */
+    public ClientBuilder keepaliveTimeMs(Long keepaliveTimeMs) {
+        // gRPC uses a minimum keepalive time of 10s, if smaller values are given.
+        // No check here though, as this gRPC value might change
+        this.keepaliveTimeMs = keepaliveTimeMs;
+        return this;
+    }
+
+    public Long keepaliveTimeoutMs() {
+        return keepaliveTimeoutMs;
+    }
+
+    /**
+     * The timeout for gRPC keepalives
+     * 
+     * @param keepaliveTimeoutMs
+     */
+    public ClientBuilder keepaliveTimeoutMs(Long keepaliveTimeoutMs) {
+        this.keepaliveTimeoutMs = keepaliveTimeoutMs;
+        return this;
+    }
+
+    public Boolean keepaliveWithoutCalls() {
+        return keepaliveWithoutCalls;
+    }
+
+    /**
+     * Keepalive option for gRPC
+     * 
+     * @param keepaliveWithoutCalls
+     */
+    public ClientBuilder keepaliveWithoutCalls(Boolean keepaliveWithoutCalls) {
+        this.keepaliveWithoutCalls = keepaliveWithoutCalls;
         return this;
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -65,9 +65,9 @@ public final class ClientBuilder implements Cloneable {
     private ByteSequence namespace = ByteSequence.EMPTY;
     private long retryDelay = 500;
     private long retryMaxDelay = 2500;
-    private Long keepaliveTimeMs;
-    private Long keepaliveTimeoutMs;
-    private Boolean keepaliveWithoutCalls;
+    private Long keepaliveTimeMs = 30000L;
+    private Long keepaliveTimeoutMs = 10000L;
+    private Boolean keepaliveWithoutCalls = true;
     private ChronoUnit retryChronoUnit = ChronoUnit.MILLIS;
     private String retryMaxDuration;
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -209,6 +210,16 @@ final class ClientConnectionManager {
             channelBuilder.sslContext(builder.sslContext());
         } else {
             channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
+        }
+
+        if (builder.keepaliveTimeMs() != null) {
+            channelBuilder.keepAliveTime(builder.keepaliveTimeMs(), TimeUnit.MILLISECONDS);
+        }
+        if (builder.keepaliveTimeoutMs() != null) {
+            channelBuilder.keepAliveTimeout(builder.keepaliveTimeoutMs(), TimeUnit.MILLISECONDS);
+        }
+        if (builder.keepaliveWithoutCalls() != null) {
+            channelBuilder.keepAliveWithoutCalls(builder.keepaliveWithoutCalls());
         }
 
         channelBuilder.nameResolverFactory(


### PR DESCRIPTION
It should be possible to provide the underlying gRPC with keepalive configuration parameters. My use case is to detect during a watch on client side, when the ETCD server is gone silently.

I didn't want to change the default behaviour of jetcd, but it may be worth to think about enabling keepalive per default. K8s seems to use 30s as default (https://github.com/kubernetes/kubernetes/blob/9d3406c27b581c0961ac5871f6893f838d59b10c/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L49)

Cheers,
Alex