### PR TITLE
Issue #769: Allow setting a connection timeout for the managed channel.

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -69,6 +69,7 @@ public final class ClientBuilder implements Cloneable {
     private Boolean keepaliveWithoutCalls = true;
     private ChronoUnit retryChronoUnit = ChronoUnit.MILLIS;
     private String retryMaxDuration;
+    private Integer connectTimeoutMs;
 
     ClientBuilder() {
     }
@@ -479,11 +480,30 @@ public final class ClientBuilder implements Cloneable {
     }
 
     /**
+     * @return the connect timeout in milliseconds.
+     */
+    public Integer connectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    /**
      * @param  retryMaxDuration the retries max duration.
      * @return                  this builder
      */
     public ClientBuilder retryMaxDuration(String retryMaxDuration) {
         this.retryMaxDuration = retryMaxDuration;
+        return this;
+    }
+
+    /**
+     * @param  connectTimeoutMs Sets the connection timeout in milliseconds.
+     * @return                  Clients connecting to fault tolerant etcd clusters (eg, clusters with >= 3 etcd server
+     *                          peers/endpoints)
+     *                          should consider a value that will allow switching timely from a crashed/partitioned peer to
+     *                          a consensus peer.
+     */
+    public ClientBuilder connectTimeoutMs(Integer connectTimeoutMs) {
+        this.connectTimeoutMs = connectTimeoutMs;
         return this;
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -55,6 +55,7 @@ import io.grpc.Status;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.AbstractStub;
+import io.netty.channel.ChannelOption;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 
@@ -220,6 +221,9 @@ final class ClientConnectionManager {
         }
         if (builder.keepaliveWithoutCalls() != null) {
             channelBuilder.keepAliveWithoutCalls(builder.keepaliveWithoutCalls());
+        }
+        if (builder.connectTimeoutMs() != null) {
+            channelBuilder.withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, builder.connectTimeoutMs());
         }
 
         channelBuilder.nameResolverFactory(


### PR DESCRIPTION
There is no simple extension to ClientBuilderTest that would allow a new test case for this, as there is no way to query options from a netty channel builder.
