### PR TITLE
Updated Failsafe usage to remove blocking call

### DIFF
--- a/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/LeaseTest.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,7 +87,7 @@ public class LeaseTest {
         assertThat(kvClient.get(KEY).get().getCount()).isEqualTo(0);
 
         tearDown();
-        assertThatExceptionOfType(ExecutionException.class)
+        assertThatExceptionOfType(RejectedExecutionException.class)
             .isThrownBy(() -> leaseClient.grant(5, 2, TimeUnit.SECONDS).get().getID());
         setUp();
     }


### PR DESCRIPTION
I'm not super familiar with Failsafe, but took a stab at fixing this blocking-bug in the connection manager.

The particular bug is with this code `getAsync(() -> task.call().get())`
This will run a blocking call `completableFuture.get()` on a thread from an executor, and calls it "async".

The default executorService is a CachedThreadPool, which is unbounded.
If a etcd has a problem under load, there is the potential that a significant number of threads get spun up.

The problem is worse, becase the executorService can be specified in the Client configuration of the client, which then gets used for this call.
In our particular case, we use an event-loop threading model with a fixed number of threads; after trying to put the etcdclient on our own executor, we saw etcd latency problems manifest as blocking our entire event-loop.