### PR TITLE
#742 Unit testing "Launcher" section needs update for JUnit 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,15 @@ The [examples](https://github.com/etcd-io/jetcd/tree/master/jetcd-examples) are 
 
 ## Launcher
 
-The `io.etcd:jetcd-launcher` offers a convenient utility to programmatically start & stop an isolated `etcd` server.  This can be very useful e.g. for integration testing, like so:
+The `io.etcd:jetcd-test` offers a convenient utility to programmatically start & stop an isolated `etcd` server.  This can be very useful e.g. for integration testing, like so:
 
 ```java
-@Rule public final EtcdClusterResource etcd = new EtcdClusterResource("test-etcd", 1);
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.test.EtcdClusterExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@RegisterExtension static final EtcdCluster etcd = new EtcdClusterExtension("test-etcd", 1);
 Client client = Client.builder().endpoints(etcd.getClientEndpoints()).build();
 ```
 


### PR DESCRIPTION
Update README "Launcher" with the new `EtcdClusterExtension` from `jetcd-test:0.5.1+`

Found the Extension had to be `static` for `beforeAll` to kick in to start the cluster automatically, otherwise `Client` will complain that `java.lang.IllegalStateException: Mapped port can only be obtained after the container is started`

Added the imports for clarity (Junit Jupiter + jetcd) - might help figure problems out if trying to use Junit 4 or still using the `jetcd-launcher` instead of `jetcd-test`.