### PR TITLE
Handling of hasleader metadata annotation and errors related to it.

### DIFF
--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
@@ -16,6 +16,7 @@
 
 package io.etcd.jetcd.common.exception;
 
+import io.grpc.Status;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -35,5 +36,12 @@ public class EtcdException extends RuntimeException {
      */
     public ErrorCode getErrorCode() {
         return code;
+    }
+
+    /**
+     * Converts to Status
+     */
+    public Status toStatus() {
+        return Status.fromCodeValue(getErrorCode().getCode()).withDescription(getMessage()).withCause(getCause());
     }
 }

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
@@ -16,7 +16,6 @@
 
 package io.etcd.jetcd.common.exception;
 
-import io.grpc.Status;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -36,12 +35,5 @@ public class EtcdException extends RuntimeException {
      */
     public ErrorCode getErrorCode() {
         return code;
-    }
-
-    /**
-     * Converts to Status
-     */
-    public Status toStatus() {
-        return Status.fromCodeValue(getErrorCode().getCode()).withDescription(getMessage()).withCause(getCause());
     }
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -479,10 +479,11 @@ public final class ClientBuilder implements Cloneable {
 
     /**
      * @param  connectTimeoutMs Sets the connection timeout in milliseconds.
-     * @return                  Clients connecting to fault tolerant etcd clusters (eg, clusters with >= 3 etcd server
+     *                          Clients connecting to fault tolerant etcd clusters (eg, clusters with >= 3 etcd server
      *                          peers/endpoints)
      *                          should consider a value that will allow switching timely from a crashed/partitioned peer to
      *                          a consensus peer.
+     * @return                  this builder
      */
     public ClientBuilder connectTimeoutMs(Integer connectTimeoutMs) {
         this.connectTimeoutMs = connectTimeoutMs;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Constants.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Constants.java
@@ -16,6 +16,8 @@
 
 package io.etcd.jetcd;
 
+import io.grpc.Metadata;
+
 /**
  * Constants of Etcd.
  */
@@ -23,4 +25,8 @@ public class Constants {
 
     public static final String TOKEN = "token";
     public static final ByteSequence NULL_KEY = ByteSequence.from(new byte[] { '\0' });
+
+    public static final Metadata.Key<String> REQUIRE_LEADER_KEY = Metadata.Key.of("hasleader",
+        Metadata.ASCII_STRING_MARSHALLER);
+    public static final String REQUIRE_LEADER_VALUE = "true";
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/LeaseImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/LeaseImpl.java
@@ -95,7 +95,7 @@ final class LeaseImpl implements Lease {
     LeaseImpl(ClientConnectionManager connectionManager) {
         this.connectionManager = connectionManager;
         this.stub = connectionManager.newStub(LeaseGrpc::newFutureStub);
-        this.leaseStub = connectionManager.newStub(LeaseGrpc::newStub);
+        this.leaseStub = Util.applyRequireLeader(true, connectionManager.newStub(LeaseGrpc::newStub));
         this.keepAlives = new ConcurrentHashMap<>();
         this.scheduledExecutorService = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(2));
     }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
@@ -46,6 +46,7 @@ public final class WatchOption {
         private boolean progressNotify = false;
         private boolean noPut = false;
         private boolean noDelete = false;
+        private boolean requireLeader = false;
 
         private Builder() {
         }
@@ -148,8 +149,23 @@ public final class WatchOption {
             return this;
         }
 
+        /**
+         * When creating the watch streaming stub, use the REQUIRED_LEADER Metadata annotation,
+         * which ensures the stream will error out if quorum is lost by
+         * the server the stream is connected to.
+         * Without this option, a stream running against a server that is out of quorum
+         * simply goes silent.
+         *
+         * @param  requireLeader require quorum for watch stream creation.
+         * @return               builder
+         */
+        public Builder withRequireLeader(boolean requireLeader) {
+            this.requireLeader = requireLeader;
+            return this;
+        }
+
         public WatchOption build() {
-            return new WatchOption(endKey, revision, prevKV, progressNotify, noPut, noDelete);
+            return new WatchOption(endKey, revision, prevKV, progressNotify, noPut, noDelete, requireLeader);
         }
 
     }
@@ -160,15 +176,17 @@ public final class WatchOption {
     private final boolean progressNotify;
     private final boolean noPut;
     private final boolean noDelete;
+    private final boolean requireLeader;
 
     private WatchOption(Optional<ByteSequence> endKey, long revision, boolean prevKV, boolean progressNotify, boolean noPut,
-        boolean noDelete) {
+        boolean noDelete, boolean requireLeader) {
         this.endKey = endKey;
         this.revision = revision;
         this.prevKV = prevKV;
         this.progressNotify = progressNotify;
         this.noPut = noPut;
         this.noDelete = noDelete;
+        this.requireLeader = requireLeader;
     }
 
     public Optional<ByteSequence> getEndKey() {
@@ -216,5 +234,19 @@ public final class WatchOption {
      */
     public boolean isNoDelete() {
         return noDelete;
+    }
+
+    /**
+     * If true, when creating the watch streaming stub, use the REQUIRED_LEADER Metadata annotation,
+     * which ensures the stream will error out if quorum is lost by
+     * the server the stream is connected to. This will make the watch fail with an error
+     * and finish.
+     * Without this option, a watch running against a server that is out of quorum
+     * simply goes silent.
+     *
+     * @return if true, use REQUIRE_LEADER metadata annotation for watch streams
+     */
+    public boolean withRequireLeader() {
+        return requireLeader;
     }
 }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @Timeout(value = 30)
 public class WatchTest {
+    private static final long timeOutSeconds = 30;
 
     @RegisterExtension
     public static final EtcdClusterExtension cluster = new EtcdClusterExtension("watch", 3);
@@ -73,7 +74,7 @@ public class WatchTest {
         try (Watcher watcher = nsClient.getWatchClient().watch(key, ref::set)) {
             // Using non-namespaced client put namespaced key.
             client.getKVClient().put(nsKey, value).get();
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get()).isNotNull();
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
@@ -93,7 +94,7 @@ public class WatchTest {
 
             client.getKVClient().put(key, value).get();
 
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get()).isNotNull();
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
@@ -116,7 +117,7 @@ public class WatchTest {
             client.getKVClient().put(key, value).get();
             latch.await(4, TimeUnit.SECONDS);
 
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(res).hasSize(2));
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(res).hasSize(2));
             assertThat(res.get(0)).usingRecursiveComparison().isEqualTo(res.get(1));
             assertThat(res.get(0).getEvents().size()).isEqualTo(1);
             assertThat(res.get(0).getEvents().get(0).getEventType()).isEqualTo(EventType.PUT);
@@ -136,7 +137,7 @@ public class WatchTest {
         try (Watcher watcher = client.getWatchClient().watch(key, ref::set)) {
             client.getKVClient().delete(key).get();
 
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
 
@@ -164,7 +165,7 @@ public class WatchTest {
         final Watch wc = client.getWatchClient();
 
         try (Watcher watcher = wc.watch(key, options, Watch.listener(TestUtil::noOpWatchResponseConsumer, ref::set))) {
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
             assertThat(ref.get().getClass()).isEqualTo(CompactedException.class);
         }
     }
@@ -178,12 +179,12 @@ public class WatchTest {
 
         try (Watcher watcher = client.getWatchClient().watch(key, events::add)) {
             client.getKVClient().put(key, value).get();
-            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).isNotEmpty());
+            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).isNotEmpty());
         }
 
         client.getKVClient().put(key, randomByteSequence()).get();
 
-        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).hasSize(1));
+        await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).hasSize(1));
         assertThat(events.get(0).getEvents()).hasSize(1);
         assertThat(events.get(0).getEvents().get(0).getEventType()).isEqualTo(EventType.PUT);
         assertThat(events.get(0).getEvents().get(0).getKeyValue().getKey()).isEqualTo(key);

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @Timeout(value = 30)
 public class WatchTest {
-    private static final long timeOutSeconds = 30;
+    private static final long TIME_OUT_SECONDS = 30;
 
     @RegisterExtension
     public static final EtcdClusterExtension cluster = new EtcdClusterExtension("watch", 3);
@@ -74,7 +74,7 @@ public class WatchTest {
         try (Watcher watcher = nsClient.getWatchClient().watch(key, ref::set)) {
             // Using non-namespaced client put namespaced key.
             client.getKVClient().put(nsKey, value).get();
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get()).isNotNull();
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
@@ -94,7 +94,7 @@ public class WatchTest {
 
             client.getKVClient().put(key, value).get();
 
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get()).isNotNull();
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
@@ -117,7 +117,7 @@ public class WatchTest {
             client.getKVClient().put(key, value).get();
             latch.await(4, TimeUnit.SECONDS);
 
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(res).hasSize(2));
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(res).hasSize(2));
             assertThat(res.get(0)).usingRecursiveComparison().isEqualTo(res.get(1));
             assertThat(res.get(0).getEvents().size()).isEqualTo(1);
             assertThat(res.get(0).getEvents().get(0).getEventType()).isEqualTo(EventType.PUT);
@@ -137,7 +137,7 @@ public class WatchTest {
         try (Watcher watcher = client.getWatchClient().watch(key, ref::set)) {
             client.getKVClient().delete(key).get();
 
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
 
             assertThat(ref.get().getEvents().size()).isEqualTo(1);
 
@@ -165,7 +165,7 @@ public class WatchTest {
         final Watch wc = client.getWatchClient();
 
         try (Watcher watcher = wc.watch(key, options, Watch.listener(TestUtil::noOpWatchResponseConsumer, ref::set))) {
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ref.get()).isNotNull());
             assertThat(ref.get().getClass()).isEqualTo(CompactedException.class);
         }
     }
@@ -179,12 +179,12 @@ public class WatchTest {
 
         try (Watcher watcher = client.getWatchClient().watch(key, events::add)) {
             client.getKVClient().put(key, value).get();
-            await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).isNotEmpty());
+            await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).isNotEmpty());
         }
 
         client.getKVClient().put(key, randomByteSequence()).get();
 
-        await().atMost(timeOutSeconds, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).hasSize(1));
+        await().atMost(TIME_OUT_SECONDS, TimeUnit.SECONDS).untilAsserted(() -> assertThat(events).hasSize(1));
         assertThat(events.get(0).getEvents()).hasSize(1);
         assertThat(events.get(0).getEvents().get(0).getEventType()).isEqualTo(EventType.PUT);
         assertThat(events.get(0).getEvents().get(0).getKeyValue().getKey()).isEqualTo(key);

--- a/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/WatchUnitTest.java
@@ -421,7 +421,7 @@ public class WatchUnitTest {
             assertThat(ref.get()).isInstanceOf(EtcdException.class)
                 .hasMessageContaining(Util.NO_LEADER_ERROR_MESSAGE);
             final WatchImpl.WatcherImpl wimpl = (WatchImpl.WatcherImpl) watcher;
-            assertThat(wimpl.isClosed());
+            assertThat(wimpl.isClosed()).isTrue();
         }
     }
 }


### PR DESCRIPTION
Some previous discussion in https://github.com/etcd-io/jetcd/issues/778#issuecomment-657763381

This diff
(1) Adds special handling for the Status(UNAVAILABLE, "etcdserver: no leader") watcher error.  The added code will prevent retrying/recreating the watcher (previously on calls to WatcherImpl.onError the watch will unconditionally be retried, WatchImpl.java:279).  Instead, the watch is closed, similar to logic in the etcd go client:
     https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/watch.go#L649
(2) Adds a "WithRequireLeader" WatchOption.  This is necessary since automated watch retries can happen outside of a client-initiated context for a WatchClient.watch() call, so it is not possible to use io.grpc.Context to set the metadata annotation reliably.
(3) Adds the hasleader,true metadata annotation to the lease stub of LeaseImpl; note the current go client does this: 
     https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/lease.go#L209
     https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/lease.go#L474
(4) Adds a unit test for the handling of the no leader status.

I also tested the behavior in with 3 machine etcd cluster; the machines were connected to the same switch in a LAN; I had a test client program connected through localhost to one of the etcd peers, as its single etcd endpoint.

The test program creates a watch on a single key and prints updates as they appear.

When created without the require leader option, as I disconnect the machine that runs the client and etcd peer from the switch, the client continues to run and wait for updates that never show up, also never failing.  Effectively the watcher goes silent as the cluster continues to allow updates to the key (as the quorum stays in the two remaining machines).

When created with the require leader option, a few seconds after disconnecting the machine onError is triggered on the listener and the watcher closes.

I am happy to share that code too although I am not sure what a good place for that is, since it is more of an integration test than a system test; creating a docker version of that test is beyond my docker capabilities sadly.

Side comment:  It seems to me the behavior or io.etcd.jetcd.Listener is different from io.grpc.stub.StreamObserver, although there is a good deal of similitude (all methods signatures match).  There seems to be a difference in the expected behavior after onError is called: the grpc StreamObserver contract is to never call any other methods after onError has been called https://grpc.github.io/grpc-java/javadoc/io/grpc/stub/StreamObserver.html#onError-java.lang.Throwable-
Since jetcd.Watcher retries the watcher, in a jetcd.Listener you effectively can get calls to onNext after a call to onError.  Perhaps I am not understanding this well; in any case, I don't think there is any problem in the jetcd.Listener contract, as long as it is explicit and understood as such.  My issue is that the similarity to grpc.stub.StreamObserver is a potential user pitfall; while reviewing uses of jetcd watchers in our own code I found 2 instances of an assumption that the watcher would be closed after onError was called on the listener, and our code was re-creating it against the same listener; I believe this would result in a bug since the listener will be notified twice after that.  The programmer coding this was used to the grpc API so their assumption was understandable.  I humbly suggest javadoc around jetcd.Listener to clarify/make this explicit; granted, the current javadoc does say "invoked on errors" (plural), but still, some additional text making the distinction more explicit might help.  Happy to provide that in a separate pull if you agree.  Using different signatures for the methods would be perhaps better, but that is an API breaking change so has its own pitfalls.

Thanks for your time!