### PR TITLE
Override ByteSequence Object.toString().

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -136,7 +136,7 @@ public final class ByteSequence {
 
     @Override
     public String toString() {
-        return toString(Charset.defaultCharset());
+        return byteString.toStringUtf8();
     }
 
     /**

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -134,6 +134,11 @@ public final class ByteSequence {
         return byteString.size();
     }
 
+    @Override
+    public String toString() {
+        return toString(Charset.defaultCharset());
+    }
+
     /**
      * Create new ByteSequence from a String.
      *
@@ -153,5 +158,4 @@ public final class ByteSequence {
     public static ByteSequence from(byte[] source) {
         return new ByteSequence(ByteString.copyFrom(source));
     }
-
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22524871/122767516-56240400-d2d5-11eb-93e7-19df7e396141.png)

Some user may use Sequence.toString directly, and didn't notice the toString(Charset charset), So override Object.toString()
by default charset.