### PR TITLE
Retry etcd requests on UNAVAILABLE

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Util.java
@@ -77,7 +77,8 @@ public final class Util {
     }
 
     static boolean isRetryable(Throwable e) {
-        return isInvalidTokenError(Status.fromThrowable(e));
+        Status status = Status.fromThrowable(e);
+        return Status.UNAVAILABLE.getCode().equals(status.getCode()) || isInvalidTokenError(status);
     }
 
     static boolean isInvalidTokenError(Status status) {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/UtilTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/UtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2021 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.jetcd;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UtilTest {
+
+    @Test
+    public void testAuthErrorIsNotRetryable() {
+        Status authErrorStatus = Status.UNAUTHENTICATED
+            .withDescription("etcdserver: invalid auth token");
+        assertThat(Util.isRetryable(new StatusException(authErrorStatus))).isTrue();
+    }
+
+    @Test
+    public void testUnavailableErrorIsRetryable() {
+        assertThat(Util.isRetryable(new StatusException(Status.UNAVAILABLE))).isTrue();
+    }
+}


### PR DESCRIPTION
This is an initial fix for #947. ~~Retries are performed on all errors
different than invalid auth token. This seams excessive.
I'm happy to discuss a smaller set of errors to retry on.~~
Retries are perform for token errors and UNAVAILABLE status.