### PR TITLE
Don't overwrite watch revision on start with the latest

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -224,7 +224,7 @@ final class WatchImpl implements Watch {
                     return;
                 }
 
-                revision = response.getHeader().getRevision();
+                revision = Math.max(revision, response.getHeader().getRevision());
                 id = response.getWatchId();
             } else if (response.getCanceled()) {
 


### PR DESCRIPTION
The latest existing revision may be older than the requested revision.
In that case the resume method (restarts a broken watch) picks up older
revision and passes to the caller unwanted events.
Use newer revision to mitigate the issue.

Fixes #946