### PR TITLE
Close cancelled watchers

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/WatchImpl.java
@@ -244,7 +244,7 @@ final class WatchImpl implements Watch {
                     error = newEtcdException(ErrorCode.FAILED_PRECONDITION, reason);
                 }
 
-                listener.onError(error);
+                handleError(toEtcdException(error), false);
             } else if (response.getEventsCount() == 0 && option.isProgressNotify()) {
 
                 //


### PR DESCRIPTION
A cancelled watcher is effectively dead and will not receive any more
events so it's helpful for users if the watcher gets closed
automatically.

Note that we don't want to reschedule the watcher since users may want
to take corrective action first, such as finding the latest revision if
the watcher was cancelled due to CompactedException.

Closes #951 