### PR TITLE
Add requestProgress function to Watch and Watcher interfaces

### DIFF
--- a/docs/Watch.md
+++ b/docs/Watch.md
@@ -12,9 +12,11 @@ The Watch provide methods to watch on a key interval and cancel a watcher. If th
 
 4. Cancel watch request, the etcd client should process watch cancellation and filter all the notification after cancellation request.
 
+5. The watch client should be able to make a progress notify request that propagates the latest revision number to all watches
+
 # Implementation
 
-The etcd client process watch request with [watch function](#watch-function), process notification with [processEvents function](#processevents-function) , process resume with [resume function](#resume-function) and process cancel with [cancelWatch function](#cancelwatch-function).
+The etcd client process watch request with [watch function](#watch-function), process notification with [processEvents function](#processevents-function) , process resume with [resume function](#resume-function), process cancel with [cancelWatch function](#cancelwatch-function) and request progress with [requestProgress function](#requestProgress-function).
 
 ## watch function
 
@@ -43,6 +45,13 @@ Cancel the watch task with the watcher, the `onCanceled` will be called after su
 
 1. The watcher will be removed from [watchers](#watchers-instance) map.
 2. If the [watchers](#watchers-instance) map contain the watcher, it will be moved to [cancelWatchers](#cancelwatchers) and send cancel request to [requestStream](#requeststream-instance).
+
+## requestProgress function
+
+Send the latest revision processed to all active [watchers](#watchers-instance)
+
+1. Send a progress request to [requestStream](#requeststream-instance).
+2. Working watchers will receive a WatchResponse containing the latest revision number. All future revision numbers are guaranteed to be greater than or equal to the received revision number.
 
 ## requestStream instance
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
@@ -140,6 +140,11 @@ public interface Watch extends CloseableClient {
         return watch(key, option, listener(onNext, onError, onCompleted));
     }
 
+    /**
+     * Requests the latest revision processed for all watcher instances
+     */
+    void requestProgress();
+
     static Listener listener(Consumer<WatchResponse> onNext) {
         return listener(onNext, t -> {
         }, () -> {
@@ -205,5 +210,10 @@ public interface Watch extends CloseableClient {
          */
         @Override
         void close();
+
+        /**
+         * Requests the latest revision processed and propagates it to listeners
+         */
+        void requestProgress();
     }
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/watch/WatchResponse.java
@@ -67,4 +67,16 @@ public class WatchResponse extends AbstractResponse<io.etcd.jetcd.api.WatchRespo
 
         return events;
     }
+
+    public boolean isProgressNotify() {
+        return isProgressNotify(getResponse());
+    }
+
+    /**
+     * returns true if the WatchResponse is progress notification.
+     */
+    public static boolean isProgressNotify(io.etcd.jetcd.api.WatchResponse response) {
+        return response.getEventsCount() == 0 && !response.getCreated() && !response.getCanceled()
+            && response.getCompactRevision() == 0 && response.getHeader().getRevision() != 0;
+    }
 }

--- a/jetcd-core/src/main/proto/kv.proto
+++ b/jetcd-core/src/main/proto/kv.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2016-2020 The jetcd authors
+// Copyright 2016-2021 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/jetcd-core/src/main/proto/rpc.proto
+++ b/jetcd-core/src/main/proto/rpc.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2016-2020 The jetcd authors
+// Copyright 2016-2021 The jetcd authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,13 @@ service KV {
 }
 
 service Watch {
+  // Progress requests that a watch stream progress status
+  // be sent in the watch response stream as soon as possible.
+  // For watch progress responses, the header.revision indicates progress. All future events
+  // received in this stream are guaranteed to have a higher revision number than the
+  // header.revision number.
+  rpc Progress(WatchProgressRequest) returns (WatchResponse) {}
+
   // Watch watches for events happening or that have happened. Both input and output
   // are streams; the input stream is for creating and canceling watchers and the output
   // stream sends events. One watch RPC can watch on multiple key ranges, streaming events
@@ -175,6 +182,9 @@ message ResponseHeader {
   // member_id is the ID of the member which sent the response.
   uint64 member_id = 2;
   // revision is the key-value store revision when the request was applied.
+  // For watch progress responses, the header.revision indicates progress. All future events
+  // recieved in this stream are guaranteed to have a higher revision number than the
+  // header.revision number.
   int64 revision = 3;
   // raft_term is the raft term when the request was applied.
   uint64 raft_term = 4;
@@ -458,6 +468,7 @@ message WatchRequest {
   oneof request_union {
     WatchCreateRequest create_request = 1;
     WatchCancelRequest cancel_request = 2;
+    WatchProgressRequest progress_request = 3;
   }
 }
 
@@ -495,6 +506,11 @@ message WatchCreateRequest {
 message WatchCancelRequest {
   // watch_id is the watcher id to cancel so that no more events are transmitted.
   int64 watch_id = 1;
+}
+
+// Requests a watch stream progress status be sent in the
+// watch response stream as soon as possible.
+message WatchProgressRequest {
 }
 
 message WatchResponse {


### PR DESCRIPTION
Added a `requestProgress` function to the `Watch` and `Watcher` interfaces to request a WatchResponse be sent to all watchers containing the latest revision number. This can be used to check if a watcher is "caught up" to a particular revision, which is useful when determining if a watch cache is stale by comparing the progress revision to the revision returned in a quorum read.

This was added to the etcd client in https://github.com/etcd-io/etcd/pull/9869 and requested for the jetcd client in https://github.com/etcd-io/jetcd/issues/928

### Commit message below

Added a function that requests a watch stream progress status
be sent in the watch response stream as soon as possible. This is
helpful in situations where an application may want to check the
progress of a watch to determine how up-to-date the watch stream is.

Addresses #928