### PR TITLE
doc: fix broken link to etcd documentation

### DIFF
--- a/jetcd-ctl/README.MD
+++ b/jetcd-ctl/README.MD
@@ -1,6 +1,6 @@
 ### jetcd-ctl
 
-Download and start an etcd node from [instruction](https://github.com/etcd-io/etcd/blob/master/Documentation/dl_build.md)
+Download and start an etcd node from [instruction](https://github.com/etcd-io/etcd/releases/latest)
 
 Put `foo` `bar` into the cluster:
 
@@ -36,10 +36,6 @@ Watch `foo` since revision 2:
 
 ```bash
 $ gradle run --args="watch foo --rev=2"
-21:43:51.360|INFO |CommandWatch - PUT
-21:43:51.361|INFO |CommandWatch - foo
-21:43:51.361|INFO |CommandWatch - bar
-21:43:51.361|INFO |CommandWatch - PUT
-21:43:51.362|INFO |CommandWatch - foo
-21:43:51.362|INFO |CommandWatch - bar2
+21:35:09.162|INFO |CommandWatch - type=PUT, key=foo, value=bar
+21:35:09.164|INFO |CommandWatch - type=PUT, key=foo, value=bar2
 ```


### PR DESCRIPTION
Hello i would like to contribute by fixing this issue - https://github.com/etcd-io/jetcd/issues/1018

For me - https://github.com/etcd-io/etcd/releases#:~:text=Compare-,v3.5.1,-Latest provides best instruction to etcd cluster creation (best working docker example)
But https://etcd.io/docs/v3.5/install/ this works better as an instruction

Fixes #1018