### PR TITLE
fix gradle dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Development snapshots are available in [Sonatypes's snapshot repository](https:/
 
 ```
 dependencies {
-    compile "io.etcd:jetcd-core:$jetcd-version"
+    implementation "io.etcd:jetcd-core:$jetcd-version"
 }
 ```
 


### PR DESCRIPTION
In Gradle 7, both the ``compile`` and ``runtime`` configurations are removed.
see, https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal