### PR TITLE
fix: key prefix support int transactions (Put and GetOpt)

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ProtoRequestMapper.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ProtoRequestMapper.java
@@ -1,0 +1,71 @@
+package io.etcd.jetcd;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import io.etcd.jetcd.api.DeleteRangeRequest;
+import io.etcd.jetcd.api.PutRequest;
+import io.etcd.jetcd.api.RangeRequest;
+import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.OptionsUtil;
+import io.etcd.jetcd.options.PutOption;
+
+import com.google.protobuf.ByteString;
+
+import static io.etcd.jetcd.options.OptionsUtil.toRangeRequestSortOrder;
+import static io.etcd.jetcd.options.OptionsUtil.toRangeRequestSortTarget;
+
+public final class ProtoRequestMapper {
+
+    private ProtoRequestMapper() {
+    }
+
+    public static RangeRequest mapRangeRequest(ByteSequence key, GetOption option, ByteSequence namespace) {
+        RangeRequest.Builder builder = RangeRequest.newBuilder()
+            .setKey(Util.prefixNamespace(key.getByteString(), namespace))
+            .setCountOnly(option.isCountOnly())
+            .setLimit(option.getLimit())
+            .setRevision(option.getRevision())
+            .setKeysOnly(option.isKeysOnly())
+            .setSerializable(option.isSerializable())
+            .setSortOrder(toRangeRequestSortOrder(option.getSortOrder()))
+            .setSortTarget(toRangeRequestSortTarget(option.getSortField()))
+            .setMinCreateRevision(option.getMinCreateRevision())
+            .setMaxCreateRevision(option.getMaxCreateRevision())
+            .setMinModRevision(option.getMinModRevision())
+            .setMaxModRevision(option.getMaxModRevision());
+
+        defineRangeRequestEnd(key, option.getEndKey(), option.isPrefix(), namespace, builder::setRangeEnd);
+        return builder.build();
+    }
+
+    public static PutRequest mapPutRequest(ByteSequence key, ByteSequence value, PutOption option, ByteSequence namespace) {
+        return PutRequest.newBuilder()
+            .setKey(Util.prefixNamespace(key.getByteString(), namespace))
+            .setValue(value.getByteString())
+            .setLease(option.getLeaseId())
+            .setPrevKv(option.getPrevKV())
+            .build();
+    }
+
+    public static DeleteRangeRequest mapDeleteRequest(ByteSequence key, DeleteOption option, ByteSequence namespace) {
+        DeleteRangeRequest.Builder builder = DeleteRangeRequest.newBuilder()
+            .setKey(Util.prefixNamespace(key.getByteString(), namespace))
+            .setPrevKv(option.isPrevKV());
+        defineRangeRequestEnd(key, option.getEndKey(), option.isPrefix(), namespace, builder::setRangeEnd);
+        return builder.build();
+    }
+
+    private static void defineRangeRequestEnd(ByteSequence key, Optional<ByteSequence> endKeyOptional,
+        boolean hasPrefix, ByteSequence namespace, Consumer<ByteString> setRangeEndConsumer) {
+        endKeyOptional.ifPresentOrElse(endKey -> {
+            setRangeEndConsumer.accept(Util.prefixNamespaceToRangeEnd(ByteString.copyFrom(endKey.getBytes()), namespace));
+        }, () -> {
+            if (hasPrefix) {
+                ByteSequence endKey = OptionsUtil.prefixEndOf(key);
+                setRangeEndConsumer.accept(Util.prefixNamespaceToRangeEnd(ByteString.copyFrom(endKey.getBytes()), namespace));
+            }
+        });
+    }
+}

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
@@ -53,7 +53,7 @@ public final class WatchOption {
         }
 
         /**
-         * Provide the revision to use for the get request.
+         * Provide the revision to use for the watch request.
          *
          * <p>
          * If the revision is less or equal to zero, the get is over the newest key-value store.
@@ -70,7 +70,7 @@ public final class WatchOption {
         }
 
         /**
-         * Set the end key of the get request. If it is set, the get request will return the keys from
+         * Set the end key of the watch request. If it is set, the get request will return the keys from
          * <i>key</i> to <i>endKey</i> (exclusive).
          *
          * <p>


### PR DESCRIPTION
Because grpc request mapping is the same for KV and Transactions, it's better for me to reuse it.
So the simplest solution was - additional static util class with this logic.

After of package changing,  [ByteSequence.toByteString](https://github.com/etcd-io/jetcd/blob/0537b7fe62f8985d2a0de554d52d2c05ec90789a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java#L117) is not longer possible. So, i have additional conversion's, which i don't like. 

Fixes #1017