### PR TITLE
fix: Update log4j to 2.15.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 grpc = "1.42.1"
-log4j = "2.14.1"
+log4j = "2.15.0"
 mockito = "4.1.0"
 slf4j = "1.7.32"
 guava = "31.0.1-jre"


### PR DESCRIPTION
The new log4j version fixes CVE-2021-44228.