### PR TITLE
Fix: use user-provided keep-alive timeouts as initial keepalive timeout

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The jetcd authors
+ * Copyright 2016-2022 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,10 @@ final class ClientConnectionManager {
             channel.shutdown();
             throw EtcdExceptionFactory.toEtcdException(e);
         }
+    }
+
+    protected ClientBuilder builder() {
+        return builder;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Use user configurable keep-alive timeouts to avoid KeepAlive being
removed before receiving first response from server

Fixes #1049