### PR TITLE
invalid etcd token with Unkonwn status code

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/support/Errors.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/support/Errors.java
@@ -20,6 +20,7 @@ import io.grpc.Status;
 
 public final class Errors {
     public static final String NO_LEADER_ERROR_MESSAGE = "etcdserver: no leader";
+    public static final String INVALID_AUTH_TOKEN_ERROR_MESSAGE = "etcdserver: invalid auth token";
 
     private Errors() {
     }
@@ -34,8 +35,8 @@ public final class Errors {
     }
 
     public static boolean isInvalidTokenError(Status status) {
-        return status.getCode() == Status.Code.UNAUTHENTICATED
-            && "etcdserver: invalid auth token".equals(status.getDescription());
+        return (status.getCode() == Status.Code.UNAUTHENTICATED || status.getCode() == Status.Code.UNKNOWN)
+            && INVALID_AUTH_TOKEN_ERROR_MESSAGE.equals(status.getDescription());
     }
 
     public static boolean isHaltError(final Status status) {


### PR DESCRIPTION
## Background
During using the etcd 3.4.16 and jetcd 0.5.10. I found that in a long running jetcd client. It will raise the Exception like `Caused by: io.etcd.jetcd.shaded.io.grpc.StatusRuntimeException: UNKNOWN: etcdserver: invalid auth token`.  The jetcd won't try to refresh the etcd token.
Also, I found the same issue: https://github.com/etcd-io/jetcd/issues/992. But he did not provide the fix. So in this PR, I just include the UNKONWN status code to refresh the etcd token.