### PR TITLE
Build: Remove workaround for gradle protoc plugin on Apple Silicon

### DIFF
--- a/jetcd-grpc/build.gradle
+++ b/jetcd-grpc/build.gradle
@@ -28,11 +28,7 @@ dependencies {
 
 protobuf {
     protoc {
-        if (osdetector.os == "osx") {
-            artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}:osx-x86_64"
-        } else {
-            artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}"
-        }
+        artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}"
     }
     plugins {
         grpc {


### PR DESCRIPTION
The [protoc-3.21.4-osx-aarch_64.exe](https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.21.4/protoc-3.21.4-osx-aarch_64.exe) is available on maven central now.