### PR TITLE
Fix mismatches of field numbers and types

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthImpl.java
@@ -264,8 +264,8 @@ final class AuthImpl extends Impl implements Auth {
 
         AuthRoleRevokePermissionRequest roleRevokePermissionRequest = AuthRoleRevokePermissionRequest.newBuilder()
             .setRoleBytes(ByteString.copyFrom(role.getBytes()))
-            .setKeyBytes(ByteString.copyFrom(key.getBytes()))
-            .setRangeEndBytes(ByteString.copyFrom(rangeEnd.getBytes()))
+            .setKey(ByteString.copyFrom(key.getBytes()))
+            .setRangeEnd(ByteString.copyFrom(rangeEnd.getBytes()))
             .build();
 
         return completable(

--- a/jetcd-grpc/src/main/proto/rpc.proto
+++ b/jetcd-grpc/src/main/proto/rpc.proto
@@ -370,7 +370,7 @@ message Compare {
   }
   // range_end compares the given target to all keys in the range [key, range_end).
   // See RangeRequest for more details on key ranges.
-  bytes range_end = 8;
+  bytes range_end = 64;
   // TODO: fill out with most of the rest of RangeRequest fields when needed.
 }
 
@@ -795,8 +795,8 @@ message AuthRoleGrantPermissionRequest {
 
 message AuthRoleRevokePermissionRequest {
   string role = 1;
-  string key = 2;
-  string range_end = 3;
+  bytes key = 2;
+  bytes range_end = 3;
 }
 
 message AuthEnableResponse {


### PR DESCRIPTION
Compared with [rpc.proto in etcd-io/etcd](https://github.com/etcd-io/etcd/blob/v3.3.0/etcdserver/etcdserverpb/rpc.proto), there are one field number mismatch and two field type mismatches.

`Compare` message has a conflict after v3.3.0 because jetcd expects `bytes range_end = 8;` while etcd defines `int64 lease = 8;`. `AuthRoleRevokePermissionRequest` message has field type conflicts between string and bytes. They could be compatible (I haven't tried it), but I think it's better to use the same type as etcd-io/etcd.

This PR fixes those mismatches.