### PR TITLE
Fix case-sensitive typo in README.md when linking to docs/SslConfig.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ GetResponse response = getFuture.get();
 // delete the key
 kvClient.delete(key).get();
 ```
-To build one ssl secured client, refer to [secured client config](docs/sslconfig.md).
+To build one ssl secured client, refer to [secured client config](docs/SslConfig.md).
 
 For full etcd v3 API, plesase refer to the [official API documentation](https://etcd.io/docs/current/learning/api/).
 


### PR DESCRIPTION
The link in the README.md to 'secured client config' returns a 404 on GitHub due to the case being wrong, this pull request is just to correct that.
