### PR TITLE
launcher: mounting data directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please follow this style to make jetcd easy to review, maintain, and develop.
 To make sure CI checks would pass please run
 
 ```bash
-./mvnw license:format
+./gradlew spotlessApply
 ```
 
 and including any changes in PR before opening it.

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
@@ -46,6 +46,7 @@ public final class Etcd {
         private boolean ssl = false;
         private List<String> additionalArgs;
         private Network network;
+        private boolean shouldMountDataDirectory = true;
 
         public Builder withClusterName(String clusterName) {
             this.clusterName = clusterName;
@@ -95,7 +96,13 @@ public final class Etcd {
                 nodes,
                 ssl,
                 additionalArgs,
-                network != null ? network : Network.newNetwork());
+                network != null ? network : Network.newNetwork(),
+                shouldMountDataDirectory);
+        }
+
+        public Builder withMountedDataDirectory(boolean shouldMountDataDirectory) {
+            this.shouldMountDataDirectory = shouldMountDataDirectory;
+            return this;
         }
     }
 }

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterImpl.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterImpl.java
@@ -43,7 +43,7 @@ public class EtcdClusterImpl implements EtcdCluster {
         int nodes,
         boolean ssl,
         Collection<String> additionalArgs,
-        Network network) {
+        Network network, boolean shouldMountDataDirectory) {
 
         this.clusterName = clusterName;
         this.network = network;
@@ -52,15 +52,12 @@ public class EtcdClusterImpl implements EtcdCluster {
             .collect(toList());
 
         this.containers = endpoints.stream()
-            .map(e -> {
-                EtcdContainer answer = new EtcdContainer(image, e, endpoints)
-                    .withClusterToken(clusterName)
-                    .withSll(ssl)
-                    .withAdditionalArgs(additionalArgs)
-                    .withNetwork(network);
-
-                return answer;
-            })
+            .map(e -> new EtcdContainer(image, e, endpoints)
+                .withClusterToken(clusterName)
+                .withSll(ssl)
+                .withAdditionalArgs(additionalArgs)
+                .withNetwork(network)
+                .withShouldMountDataDirectory(shouldMountDataDirectory))
             .collect(toList());
     }
 

--- a/jetcd-launcher/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterStartTest.java
+++ b/jetcd-launcher/src/test/java/io/etcd/jetcd/launcher/test/EtcdClusterStartTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test;
 import io.etcd.jetcd.launcher.Etcd;
 import io.etcd.jetcd.launcher.EtcdCluster;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class EtcdClusterStartTest {
 
     @Test
@@ -32,10 +35,34 @@ public class EtcdClusterStartTest {
 
     @Test
     public void testStartEtcdWithAdditionalArguments() throws Exception {
-
         try (EtcdCluster etcd = Etcd.builder().withClusterName(getClass().getSimpleName())
             .withAdditionalArgs("--max-txn-ops", "1024").build()) {
             etcd.start();
         }
     }
+
+    @Test
+    public void testContainerShouldMountDirectory() {
+        try (EtcdCluster etcd = Etcd.builder().withClusterName(getClass().getSimpleName()).withMountedDataDirectory(true)
+            .build()) {
+            etcd.start();
+
+            var containers = etcd.containers();
+
+            containers.forEach(container -> assertTrue(container.hasDataDirectoryMounted(), "Data directory was not mounted"));
+        }
+    }
+
+    @Test
+    public void testContainerShouldNotMountDirectory() {
+        try (EtcdCluster etcd = Etcd.builder().withClusterName(getClass().getSimpleName()).withMountedDataDirectory(false)
+            .build()) {
+            etcd.start();
+
+            var containers = etcd.containers();
+
+            containers.forEach(container -> assertFalse(container.hasDataDirectoryMounted(), "Data directory was mounted"));
+        }
+    }
+
 }

--- a/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
+++ b/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
@@ -153,6 +153,11 @@ public class EtcdClusterExtension implements BeforeAllCallback, BeforeEachCallba
             return this;
         }
 
+        public Builder withMountDirectory(boolean mountDirectory) {
+            builder.withMountedDataDirectory(mountDirectory);
+            return this;
+        }
+
         public EtcdClusterExtension build() {
             return new EtcdClusterExtension(builder.build());
         }


### PR DESCRIPTION
Hello! Thank you for you work on this library! 

About PR: 
- Fix `CONTRIBUTING.md`
- launcher: mounting data directory

## Fix `CONTRIBUTING.md`

The file was not up to date. As far as I understand maven you use gradle now. 

## launcher: mounting data directory

We have limitations during test execution. We are not allowed to mount directories on host machine. New option `shouldMountDataDirectory` is meant to fix the problem. We will be able to turn-off mounting of the directory.

Hope this wil be helpful! 

## Problems 

I wrote some tests but I wasn't able to run them. I have 2 laptops: 
- M1 MacBook is not able to run ETCD containers.
- Intel MacBook got `gradle test` task stuck (I suppose I have this problem https://github.com/gradle/gradle/issues/20455)
