### PR TITLE
Remove quote from properties' values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 #
 # project
 #
-gitProject  = 'https://github.com/etcd-io/jetcd'
-gitURL      = 'git@github.com/etcd-io/jetcd.git'
+gitProject  = https://github.com/etcd-io/jetcd
+gitURL      = git@github.com/etcd-io/jetcd.git
 
 #
 # gradle


### PR DESCRIPTION
The value of properties should not contain a quote, otherwise, may cause metadata files malformed, e.g. `pom.xml`

<img width="583" alt="image" src="https://github.com/etcd-io/jetcd/assets/26535726/b146aa54-c4e7-46a8-a886-9b0004a8b585">
