### PR TITLE
fix: unnecessary transient in MemorizingClientSupplier

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/support/MemorizingClientSupplier.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/support/MemorizingClientSupplier.java
@@ -21,8 +21,8 @@ import java.util.function.Supplier;
 
 public class MemorizingClientSupplier<T extends CloseableClient> implements Supplier<T>, CloseableClient {
     final Supplier<T> delegate;
-    transient volatile boolean initialized;
-    transient T value;
+    volatile boolean initialized;
+    T value;
 
     public MemorizingClientSupplier(Supplier<T> delegate) {
         this.delegate = Objects.requireNonNull(delegate);


### PR DESCRIPTION
Now that `MemorizingClientSupplier` is not `Serializable`, it is unnecessary to declare `transient` fields.