### PR TITLE
replace usage of guava with standard java

### DIFF
--- a/jetcd-common/build.gradle
+++ b/jetcd-common/build.gradle
@@ -17,6 +17,7 @@
 
 dependencies {
     api libs.slf4j
+    api libs.guava
     api libs.grpcCore
 
     testImplementation libs.bundles.testing

--- a/jetcd-common/build.gradle
+++ b/jetcd-common/build.gradle
@@ -17,7 +17,6 @@
 
 dependencies {
     api libs.slf4j
-    api libs.guava
     api libs.grpcCore
 
     testImplementation libs.bundles.testing

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdException.java
@@ -16,7 +16,7 @@
 
 package io.etcd.jetcd.common.exception;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Base exception type for all exceptions produced by the etcd service.
@@ -27,7 +27,7 @@ public class EtcdException extends RuntimeException {
 
     EtcdException(ErrorCode code, String message, Throwable cause) {
         super(message, cause);
-        this.code = checkNotNull(code);
+        this.code = Objects.requireNonNull(code, "Error code must not be null");
     }
 
     /**

--- a/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdExceptionFactory.java
+++ b/jetcd-common/src/main/java/io/etcd/jetcd/common/exception/EtcdExceptionFactory.java
@@ -16,9 +16,10 @@
 
 package io.etcd.jetcd.common.exception;
 
+import java.util.Objects;
+
 import io.grpc.Status;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.Status.fromThrowable;
 
 /**
@@ -65,7 +66,7 @@ public final class EtcdExceptionFactory {
     }
 
     public static EtcdException toEtcdException(Throwable cause) {
-        checkNotNull(cause, "cause can't be null");
+        Objects.requireNonNull(cause, "cause can't be null");
         if (cause instanceof EtcdException) {
             return (EtcdException) cause;
         }
@@ -74,7 +75,7 @@ public final class EtcdExceptionFactory {
     }
 
     public static EtcdException toEtcdException(Status status) {
-        checkNotNull(status, "status can't be null");
+        Objects.requireNonNull(status, "status can't be null");
         return fromStatus(status);
     }
 

--- a/jetcd-core/build.gradle
+++ b/jetcd-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     api project(':jetcd-common')
 
     api libs.slf4j
+    api libs.guava
     api libs.failsafe
 
     //compileOnly libs.javaxAnnotation

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ByteSequence.java
@@ -17,8 +17,8 @@
 package io.etcd.jetcd;
 
 import java.nio.charset.Charset;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 
 /**
@@ -32,7 +32,7 @@ public final class ByteSequence {
     private final ByteString byteString;
 
     private ByteSequence(ByteString byteString) {
-        Preconditions.checkNotNull(byteString, "byteString should not be null");
+        Objects.requireNonNull(byteString, "byteString should not be null");
         this.byteString = byteString;
         this.hashVal = byteString.hashCode();
     }
@@ -58,7 +58,7 @@ public final class ByteSequence {
      * @return       a new {@code ByteSequence} instance
      */
     public ByteSequence concat(ByteSequence other) {
-        Preconditions.checkNotNull(other, "other byteSequence should not be null");
+        Objects.requireNonNull(other, "other byteSequence should not be null");
         return new ByteSequence(this.byteString.concat(other.byteString));
     }
 
@@ -69,7 +69,7 @@ public final class ByteSequence {
      * @return       a new {@code ByteSequence} instance
      */
     public ByteSequence concat(ByteString other) {
-        Preconditions.checkNotNull(other, "other byteSequence should not be null");
+        Objects.requireNonNull(other, "other byteSequence should not be null");
         return new ByteSequence(this.byteString.concat(other));
     }
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.net.ssl.SSLException;
 
@@ -37,9 +38,7 @@ import io.grpc.netty.GrpcSslContexts;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.Streams;
 
 /**
  * ClientBuilder knows how to create a Client instance.
@@ -131,7 +130,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws IllegalArgumentException if some endpoint is invalid
      */
     public ClientBuilder endpoints(Iterable<URI> endpoints) {
-        Preconditions.checkNotNull(endpoints, "endpoints can't be null");
+        Objects.requireNonNull(endpoints, "endpoints can't be null");
 
         endpoints.forEach(e -> {
             if (e.getHost() == null) {
@@ -139,7 +138,7 @@ public final class ClientBuilder implements Cloneable {
             }
         });
 
-        final String target = Streams.stream(endpoints)
+        final String target = StreamSupport.stream(endpoints.spliterator(), false)
             .map(e -> e.getHost() + (e.getPort() != -1 ? ":" + e.getPort() : ""))
             .distinct()
             .collect(Collectors.joining(","));
@@ -173,7 +172,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws NullPointerException if user is <code>null</code>
      */
     public ClientBuilder user(ByteSequence user) {
-        Preconditions.checkNotNull(user, "user can't be null");
+        Objects.requireNonNull(user, "user can't be null");
         this.user = user;
         return this;
     }
@@ -195,7 +194,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws NullPointerException if password is <code>null</code>
      */
     public ClientBuilder password(ByteSequence password) {
-        Preconditions.checkNotNull(password, "password can't be null");
+        Objects.requireNonNull(password, "password can't be null");
         this.password = password;
         return this;
     }
@@ -218,7 +217,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws NullPointerException if namespace is <code>null</code>
      */
     public ClientBuilder namespace(ByteSequence namespace) {
-        Preconditions.checkNotNull(namespace, "namespace can't be null");
+        Objects.requireNonNull(namespace, "namespace can't be null");
         this.namespace = namespace;
         return this;
     }
@@ -240,7 +239,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws NullPointerException if executorService is <code>null</code>
      */
     public ClientBuilder executorService(ExecutorService executorService) {
-        Preconditions.checkNotNull(executorService, "executorService can't be null");
+        Objects.requireNonNull(executorService, "executorService can't be null");
         this.executorService = executorService;
         return this;
     }
@@ -253,7 +252,7 @@ public final class ClientBuilder implements Cloneable {
      * @throws NullPointerException if loadBalancerPolicy is <code>null</code>
      */
     public ClientBuilder loadBalancerPolicy(String loadBalancerPolicy) {
-        Preconditions.checkNotNull(loadBalancerPolicy, "loadBalancerPolicy can't be null");
+        Objects.requireNonNull(loadBalancerPolicy, "loadBalancerPolicy can't be null");
         this.loadBalancerPolicy = loadBalancerPolicy;
         return this;
     }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/Preconditions.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The jetcd authors
+ * Copyright 2016-2023 The jetcd authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-dependencies {
-    api project(':jetcd-api')
-    api project(':jetcd-launcher')
+package io.etcd.jetcd;
 
-    api libs.slf4j
-    api libs.bundles.grpc
-    api libs.bundles.grpcTest
+public class Preconditions {
 
-    api libs.junit
-    api libs.autoServiceAnnotations
+    public static void checkArgument(boolean expression, String errorMessage) {
+        if (!expression) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
 
-    annotationProcessor libs.autoServiceProcessor
-
-    testRuntimeOnly libs.bundles.log4j
+    public static void checkState(boolean expression, String errorMessage) {
+        if (!expression) {
+            throw new IllegalStateException(errorMessage);
+        }
+    }
 }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthCredential.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthCredential.java
@@ -31,7 +31,7 @@ import io.grpc.stub.MetadataUtils;
 
 import com.google.protobuf.ByteString;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static io.etcd.jetcd.Preconditions.checkArgument;
 
 /**
  * AuthTokenInterceptor fills header with Auth token of any rpc calls and

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/AuthImpl.java
@@ -55,7 +55,7 @@ import io.etcd.jetcd.auth.Permission;
 
 import com.google.protobuf.ByteString;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of etcd auth client.
@@ -88,8 +88,8 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserAddResponse> userAdd(ByteSequence user, ByteSequence password) {
-        checkNotNull(user, "user can't be null");
-        checkNotNull(password, "password can't be null");
+        requireNonNull(user, "user can't be null");
+        requireNonNull(password, "password can't be null");
 
         AuthUserAddRequest addRequest = AuthUserAddRequest.newBuilder()
             .setNameBytes(ByteString.copyFrom(user.getBytes()))
@@ -103,7 +103,7 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserDeleteResponse> userDelete(ByteSequence user) {
-        checkNotNull(user, "user can't be null");
+        requireNonNull(user, "user can't be null");
 
         AuthUserDeleteRequest deleteRequest = AuthUserDeleteRequest.newBuilder()
             .setNameBytes(ByteString.copyFrom(user.getBytes()))
@@ -116,8 +116,8 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserChangePasswordResponse> userChangePassword(ByteSequence user, ByteSequence password) {
-        checkNotNull(user, "user can't be null");
-        checkNotNull(password, "password can't be null");
+        requireNonNull(user, "user can't be null");
+        requireNonNull(password, "password can't be null");
 
         AuthUserChangePasswordRequest changePasswordRequest = AuthUserChangePasswordRequest.newBuilder()
             .setNameBytes(ByteString.copyFrom(user.getBytes()))
@@ -131,7 +131,7 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserGetResponse> userGet(ByteSequence user) {
-        checkNotNull(user, "user can't be null");
+        requireNonNull(user, "user can't be null");
 
         AuthUserGetRequest userGetRequest = AuthUserGetRequest.newBuilder()
             .setNameBytes(ByteString.copyFrom(user.getBytes()))
@@ -153,8 +153,8 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserGrantRoleResponse> userGrantRole(ByteSequence user, ByteSequence role) {
-        checkNotNull(user, "user can't be null");
-        checkNotNull(role, "key can't be null");
+        requireNonNull(user, "user can't be null");
+        requireNonNull(role, "key can't be null");
 
         AuthUserGrantRoleRequest userGrantRoleRequest = AuthUserGrantRoleRequest.newBuilder()
             .setUserBytes(ByteString.copyFrom(user.getBytes()))
@@ -168,8 +168,8 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthUserRevokeRoleResponse> userRevokeRole(ByteSequence user, ByteSequence role) {
-        checkNotNull(user, "user can't be null");
-        checkNotNull(role, "key can't be null");
+        requireNonNull(user, "user can't be null");
+        requireNonNull(role, "key can't be null");
 
         AuthUserRevokeRoleRequest userRevokeRoleRequest = AuthUserRevokeRoleRequest.newBuilder()
             .setNameBytes(ByteString.copyFrom(user.getBytes()))
@@ -183,7 +183,7 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthRoleAddResponse> roleAdd(ByteSequence user) {
-        checkNotNull(user, "user can't be null");
+        requireNonNull(user, "user can't be null");
 
         AuthRoleAddRequest roleAddRequest = AuthRoleAddRequest.newBuilder().setNameBytes(ByteString.copyFrom(user.getBytes()))
             .build();
@@ -196,10 +196,10 @@ final class AuthImpl extends Impl implements Auth {
     @Override
     public CompletableFuture<AuthRoleGrantPermissionResponse> roleGrantPermission(ByteSequence role, ByteSequence key,
         ByteSequence rangeEnd, Permission.Type permType) {
-        checkNotNull(role, "role can't be null");
-        checkNotNull(key, "key can't be null");
-        checkNotNull(rangeEnd, "rangeEnd can't be null");
-        checkNotNull(permType, "permType can't be null");
+        requireNonNull(role, "role can't be null");
+        requireNonNull(key, "key can't be null");
+        requireNonNull(rangeEnd, "rangeEnd can't be null");
+        requireNonNull(permType, "permType can't be null");
 
         io.etcd.jetcd.api.Permission.Type type;
         switch (permType) {
@@ -235,7 +235,7 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthRoleGetResponse> roleGet(ByteSequence role) {
-        checkNotNull(role, "role can't be null");
+        requireNonNull(role, "role can't be null");
 
         AuthRoleGetRequest roleGetRequest = AuthRoleGetRequest.newBuilder()
             .setRoleBytes(ByteString.copyFrom(role.getBytes()))
@@ -258,9 +258,9 @@ final class AuthImpl extends Impl implements Auth {
     @Override
     public CompletableFuture<AuthRoleRevokePermissionResponse> roleRevokePermission(ByteSequence role, ByteSequence key,
         ByteSequence rangeEnd) {
-        checkNotNull(role, "role can't be null");
-        checkNotNull(key, "key can't be null");
-        checkNotNull(rangeEnd, "rangeEnd can't be null");
+        requireNonNull(role, "role can't be null");
+        requireNonNull(key, "key can't be null");
+        requireNonNull(rangeEnd, "rangeEnd can't be null");
 
         AuthRoleRevokePermissionRequest roleRevokePermissionRequest = AuthRoleRevokePermissionRequest.newBuilder()
             .setRoleBytes(ByteString.copyFrom(role.getBytes()))
@@ -275,7 +275,7 @@ final class AuthImpl extends Impl implements Auth {
 
     @Override
     public CompletableFuture<AuthRoleDeleteResponse> roleDelete(ByteSequence role) {
-        checkNotNull(role, "role can't be null");
+        requireNonNull(role, "role can't be null");
         AuthRoleDeleteRequest roleDeleteRequest = AuthRoleDeleteRequest.newBuilder()
             .setRoleBytes(ByteString.copyFrom(role.getBytes()))
             .build();

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/ElectionImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/ElectionImpl.java
@@ -37,8 +37,8 @@ import io.grpc.StatusRuntimeException;
 
 import com.google.protobuf.ByteString;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.toEtcdException;
+import static java.util.Objects.requireNonNull;
 
 final class ElectionImpl extends Impl implements Election {
     private final VertxElectionGrpc.ElectionVertxStub stub;
@@ -53,8 +53,8 @@ final class ElectionImpl extends Impl implements Election {
 
     @Override
     public CompletableFuture<CampaignResponse> campaign(ByteSequence electionName, long leaseId, ByteSequence proposal) {
-        checkNotNull(electionName, "election name should not be null");
-        checkNotNull(proposal, "proposal should not be null");
+        requireNonNull(electionName, "election name should not be null");
+        requireNonNull(proposal, "proposal should not be null");
 
         CampaignRequest request = CampaignRequest.newBuilder()
             .setName(Util.prefixNamespace(electionName, namespace))
@@ -70,8 +70,8 @@ final class ElectionImpl extends Impl implements Election {
 
     @Override
     public CompletableFuture<ProclaimResponse> proclaim(LeaderKey leaderKey, ByteSequence proposal) {
-        checkNotNull(leaderKey, "leader key should not be null");
-        checkNotNull(proposal, "proposal should not be null");
+        requireNonNull(leaderKey, "leader key should not be null");
+        requireNonNull(proposal, "proposal should not be null");
 
         ProclaimRequest request = ProclaimRequest.newBuilder()
             .setLeader(
@@ -92,7 +92,7 @@ final class ElectionImpl extends Impl implements Election {
 
     @Override
     public CompletableFuture<LeaderResponse> leader(ByteSequence electionName) {
-        checkNotNull(electionName, "election name should not be null");
+        requireNonNull(electionName, "election name should not be null");
 
         LeaderRequest request = LeaderRequest.newBuilder()
             .setName(Util.prefixNamespace(electionName, namespace))
@@ -106,8 +106,8 @@ final class ElectionImpl extends Impl implements Election {
 
     @Override
     public void observe(ByteSequence electionName, Listener listener) {
-        checkNotNull(electionName, "election name should not be null");
-        checkNotNull(listener, "listener should not be null");
+        requireNonNull(electionName, "election name should not be null");
+        requireNonNull(listener, "listener should not be null");
 
         LeaderRequest request = LeaderRequest.newBuilder()
             .setName(ByteString.copyFrom(electionName.getBytes()))
@@ -121,7 +121,7 @@ final class ElectionImpl extends Impl implements Election {
 
     @Override
     public CompletableFuture<ResignResponse> resign(LeaderKey leaderKey) {
-        checkNotNull(leaderKey, "leader key should not be null");
+        requireNonNull(leaderKey, "leader key should not be null");
 
         ResignRequest request = ResignRequest.newBuilder()
             .setLeader(

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/KVImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/KVImpl.java
@@ -36,7 +36,7 @@ import io.etcd.jetcd.options.PutOption;
 import io.etcd.jetcd.support.Errors;
 import io.etcd.jetcd.support.Requests;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of etcd kv client.
@@ -59,9 +59,9 @@ final class KVImpl extends Impl implements KV {
 
     @Override
     public CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value, PutOption option) {
-        checkNotNull(key, "key should not be null");
-        checkNotNull(value, "value should not be null");
-        checkNotNull(option, "option should not be null");
+        requireNonNull(key, "key should not be null");
+        requireNonNull(value, "value should not be null");
+        requireNonNull(option, "option should not be null");
         return execute(
             () -> stub.put(Requests.mapPutRequest(key, value, option, namespace)),
             response -> new PutResponse(response, namespace),
@@ -75,8 +75,8 @@ final class KVImpl extends Impl implements KV {
 
     @Override
     public CompletableFuture<GetResponse> get(ByteSequence key, GetOption option) {
-        checkNotNull(key, "key should not be null");
-        checkNotNull(option, "option should not be null");
+        requireNonNull(key, "key should not be null");
+        requireNonNull(option, "option should not be null");
 
         return execute(
             () -> stub.range(Requests.mapRangeRequest(key, option, namespace)),
@@ -91,8 +91,8 @@ final class KVImpl extends Impl implements KV {
 
     @Override
     public CompletableFuture<DeleteResponse> delete(ByteSequence key, DeleteOption option) {
-        checkNotNull(key, "key should not be null");
-        checkNotNull(option, "option should not be null");
+        requireNonNull(key, "key should not be null");
+        requireNonNull(option, "option should not be null");
 
         return execute(
             () -> stub.deleteRange(Requests.mapDeleteRequest(key, option, namespace)),
@@ -107,7 +107,7 @@ final class KVImpl extends Impl implements KV {
 
     @Override
     public CompletableFuture<CompactResponse> compact(long rev, CompactOption option) {
-        checkNotNull(option, "option should not be null");
+        requireNonNull(option, "option should not be null");
 
         CompactionRequest request = CompactionRequest.newBuilder()
             .setRevision(rev).setPhysical(option.isPhysical())

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/LeaseImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/LeaseImpl.java
@@ -40,8 +40,8 @@ import io.etcd.jetcd.support.Util;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.streams.WriteStream;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.etcd.jetcd.common.exception.EtcdExceptionFactory.*;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of lease client.
@@ -103,7 +103,7 @@ final class LeaseImpl extends Impl implements Lease {
 
     @Override
     public CompletableFuture<LeaseTimeToLiveResponse> timeToLive(long leaseId, LeaseOption option) {
-        checkNotNull(option, "LeaseOption should not be null");
+        requireNonNull(option, "LeaseOption should not be null");
 
         LeaseTimeToLiveRequest leaseTimeToLiveRequest = LeaseTimeToLiveRequest.newBuilder()
             .setID(leaseId)

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/LockImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/LockImpl.java
@@ -28,7 +28,7 @@ import io.etcd.jetcd.lock.UnlockResponse;
 import io.etcd.jetcd.support.Errors;
 import io.etcd.jetcd.support.Util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 final class LockImpl extends Impl implements Lock {
     private final VertxLockGrpc.LockVertxStub stub;
@@ -43,7 +43,7 @@ final class LockImpl extends Impl implements Lock {
 
     @Override
     public CompletableFuture<LockResponse> lock(ByteSequence name, long leaseId) {
-        checkNotNull(name);
+        requireNonNull(name);
 
         LockRequest request = LockRequest.newBuilder()
             .setName(Util.prefixNamespace(name, namespace))
@@ -58,7 +58,7 @@ final class LockImpl extends Impl implements Lock {
 
     @Override
     public CompletableFuture<UnlockResponse> unlock(ByteSequence lockKey) {
-        checkNotNull(lockKey);
+        requireNonNull(lockKey);
 
         UnlockRequest request = UnlockRequest.newBuilder()
             .setKey(Util.prefixNamespace(lockKey, namespace))

--- a/jetcd-core/src/main/java/io/etcd/jetcd/op/TxnImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/op/TxnImpl.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.op;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -27,7 +28,6 @@ import io.etcd.jetcd.api.TxnRequest;
 import io.etcd.jetcd.kv.TxnResponse;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 
 /**
  * Build an etcd transaction.
@@ -60,7 +60,7 @@ public class TxnImpl implements Txn {
 
     @Override
     public TxnImpl If(Cmp... cmps) {
-        return If(ImmutableList.copyOf(cmps));
+        return If(Arrays.asList(cmps));
     }
 
     TxnImpl If(List<Cmp> cmps) {
@@ -77,7 +77,7 @@ public class TxnImpl implements Txn {
 
     @Override
     public TxnImpl Then(Op... ops) {
-        return Then(ImmutableList.copyOf(ops));
+        return Then(Arrays.asList(ops));
     }
 
     TxnImpl Then(List<Op> ops) {
@@ -93,7 +93,7 @@ public class TxnImpl implements Txn {
 
     @Override
     public TxnImpl Else(Op... ops) {
-        return Else(ImmutableList.copyOf(ops));
+        return Else(Arrays.asList(ops));
     }
 
     TxnImpl Else(List<Op> ops) {

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/DeleteOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/DeleteOption.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class DeleteOption {
     public static final DeleteOption DEFAULT = builder().build();
@@ -127,7 +127,7 @@ public final class DeleteOption {
          */
         @Deprecated
         public Builder withPrefix(ByteSequence prefix) {
-            checkNotNull(prefix, "prefix should not be null");
+            requireNonNull(prefix, "prefix should not be null");
             ByteSequence prefixEnd = OptionsUtil.prefixEndOf(prefix);
             this.withRange(prefixEnd);
             return this;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/GetOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/GetOption.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The option for get operation.
@@ -309,7 +309,7 @@ public final class GetOption {
          */
         @Deprecated
         public Builder withPrefix(ByteSequence prefix) {
-            checkNotNull(prefix, "prefix should not be null");
+            requireNonNull(prefix, "prefix should not be null");
             ByteSequence prefixEnd = OptionsUtil.prefixEndOf(prefix);
             this.withRange(prefixEnd);
             return this;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/options/WatchOption.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import io.etcd.jetcd.ByteSequence;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The option for watch operation.
@@ -273,7 +273,7 @@ public final class WatchOption {
          */
         @Deprecated
         public Builder withPrefix(ByteSequence prefix) {
-            checkNotNull(prefix, "prefix should not be null");
+            requireNonNull(prefix, "prefix should not be null");
             ByteSequence prefixEnd = OptionsUtil.prefixEndOf(prefix);
             this.withRange(prefixEnd);
             return this;

--- a/jetcd-core/src/main/java/io/etcd/jetcd/resolver/AbstractNameResolver.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/resolver/AbstractNameResolver.java
@@ -18,6 +18,7 @@ package io.etcd.jetcd.resolver;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public abstract class AbstractNameResolver extends NameResolver {
         synchronized (lock) {
             Preconditions.checkState(this.listener == null, "already started");
             this.executor = SharedResourceHolder.get(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
-            this.listener = Preconditions.checkNotNull(listener, "listener");
+            this.listener = Objects.requireNonNull(listener, "listener");
             resolve();
         }
     }

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/KVTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/KVTest.java
@@ -20,7 +20,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -45,7 +50,6 @@ import io.etcd.jetcd.options.GetOption.SortTarget;
 import io.etcd.jetcd.options.PutOption;
 import io.etcd.jetcd.test.EtcdClusterExtension;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static io.etcd.jetcd.impl.TestUtil.bytesOf;
 import static io.etcd.jetcd.impl.TestUtil.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +85,8 @@ public class KVTest {
         ByteSequence key = bytesOf(keyString);
         ByteSequence prefixedKey = prefix.concat(subPrefix).concat(key);
         assertThat(prefixedKey.startsWith(prefix)).isTrue();
-        assertThat(prefixedKey.substring(prefix.size() + subPrefix.size()).toString(UTF_8)).isEqualTo(keyString);
+        assertThat(prefixedKey.substring(prefix.size() + subPrefix.size()).toString(StandardCharsets.UTF_8))
+            .isEqualTo(keyString);
         assertThat(prefixedKey.substring(prefix.size(), prefix.size() + subPrefix.size())).isEqualTo(subPrefix);
     }
 
@@ -108,7 +113,8 @@ public class KVTest {
         CompletableFuture<GetResponse> getFeature = kvClient.get(SAMPLE_KEY_2);
         GetResponse response = getFeature.get();
         assertThat(response.getKvs()).hasSize(1);
-        assertThat(response.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(SAMPLE_VALUE_2.toString(UTF_8));
+        assertThat(response.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(SAMPLE_VALUE_2.toString(StandardCharsets.UTF_8));
         assertThat(!response.isMore()).isTrue();
     }
 
@@ -121,7 +127,8 @@ public class KVTest {
         CompletableFuture<GetResponse> getFeature = kvClient.get(SAMPLE_KEY_3, option);
         GetResponse response = getFeature.get();
         assertThat(response.getKvs()).hasSize(1);
-        assertThat(response.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(SAMPLE_VALUE.toString(UTF_8));
+        assertThat(response.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(SAMPLE_VALUE.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -137,8 +144,10 @@ public class KVTest {
 
         assertThat(response.getKvs()).hasSize(numPrefix);
         for (int i = 0; i < numPrefix; i++) {
-            assertThat(response.getKvs().get(i).getKey().toString(UTF_8)).isEqualTo(prefix + (numPrefix - i - 1));
-            assertThat(response.getKvs().get(i).getValue().toString(UTF_8)).isEqualTo(String.valueOf(numPrefix - i - 1));
+            assertThat(response.getKvs().get(i).getKey().toString(StandardCharsets.UTF_8))
+                .isEqualTo(prefix + (numPrefix - i - 1));
+            assertThat(response.getKvs().get(i).getValue().toString(StandardCharsets.UTF_8))
+                .isEqualTo(String.valueOf(numPrefix - i - 1));
         }
     }
 
@@ -207,7 +216,8 @@ public class KVTest {
         // get the value
         GetResponse getResp = kvClient.get(sampleKey).get();
         assertThat(getResp.getKvs()).hasSize(1);
-        assertThat(getResp.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(putValue.toString(UTF_8));
+        assertThat(getResp.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(putValue.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -255,7 +265,8 @@ public class KVTest {
         // get the value
         GetResponse getResp = kvClient.get(sampleKey).get();
         assertThat(getResp.getKvs()).hasSize(1);
-        assertThat(getResp.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(putValue.toString(UTF_8));
+        assertThat(getResp.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(putValue.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -276,11 +287,13 @@ public class KVTest {
 
         GetResponse getResp = kvClient.get(foo).get();
         assertThat(getResp.getKvs()).hasSize(1);
-        assertThat(getResp.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(bar.toString(UTF_8));
+        assertThat(getResp.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(bar.toString(StandardCharsets.UTF_8));
 
         GetResponse getResp2 = kvClient.get(abc).get();
         assertThat(getResp2.getKvs()).hasSize(1);
-        assertThat(getResp2.getKvs().get(0).getValue().toString(UTF_8)).isEqualTo(oneTwoThree.toString(UTF_8));
+        assertThat(getResp2.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8))
+            .isEqualTo(oneTwoThree.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/LeaseMemoryLeakTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/LeaseMemoryLeakTest.java
@@ -17,6 +17,7 @@
 package io.etcd.jetcd.impl;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -24,16 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.etcd.jetcd.ByteSequence;
-import io.etcd.jetcd.Client;
-import io.etcd.jetcd.KV;
-import io.etcd.jetcd.Lease;
-import io.etcd.jetcd.options.PutOption;
-import io.etcd.jetcd.test.EtcdClusterExtension;
-import io.restassured.RestAssured;
-
-import com.google.common.base.Charsets;
 
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.AfterEach;
@@ -44,6 +35,14 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.options.PutOption;
+import io.etcd.jetcd.test.EtcdClusterExtension;
+import io.restassured.RestAssured;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,8 +62,8 @@ public class LeaseMemoryLeakTest {
     private static final long TTL = 10;
     private static final int ITERATIONS = 5;
     private static final Pattern GO_ROUTINES_EXTRACT_PATTERN = Pattern.compile("go_goroutines (\\d+)");
-    private static final ByteSequence KEY = ByteSequence.from("foo", Charsets.UTF_8);
-    private static final ByteSequence VALUE = ByteSequence.from("bar", Charsets.UTF_8);
+    private static final ByteSequence KEY = ByteSequence.from("foo", StandardCharsets.UTF_8);
+    private static final ByteSequence VALUE = ByteSequence.from("bar", StandardCharsets.UTF_8);
 
     @BeforeEach
     public void setUp() {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/LeaseTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/LeaseTest.java
@@ -16,6 +16,7 @@
 
 package io.etcd.jetcd.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -40,9 +41,9 @@ import io.etcd.jetcd.support.Observers;
 import io.etcd.jetcd.test.EtcdClusterExtension;
 import io.grpc.stub.StreamObserver;
 
-import com.google.common.base.Charsets;
-
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
@@ -57,9 +58,9 @@ public class LeaseTest {
     private Client client;
     private Lease leaseClient;
 
-    private static final ByteSequence KEY = ByteSequence.from("foo", Charsets.UTF_8);
-    private static final ByteSequence KEY_2 = ByteSequence.from("foo2", Charsets.UTF_8);
-    private static final ByteSequence VALUE = ByteSequence.from("bar", Charsets.UTF_8);
+    private static final ByteSequence KEY = ByteSequence.from("foo", StandardCharsets.UTF_8);
+    private static final ByteSequence KEY_2 = ByteSequence.from("foo2", StandardCharsets.UTF_8);
+    private static final ByteSequence VALUE = ByteSequence.from("bar", StandardCharsets.UTF_8);
 
     @BeforeEach
     public void setUp() {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/LockTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/LockTest.java
@@ -16,6 +16,7 @@
 
 package io.etcd.jetcd.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -41,8 +42,6 @@ import io.etcd.jetcd.lease.LeaseGrantResponse;
 import io.etcd.jetcd.lock.LockResponse;
 import io.etcd.jetcd.test.EtcdClusterExtension;
 
-import com.google.common.base.Charsets;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -57,9 +56,9 @@ public class LockTest {
     private static Lease leaseClient;
     private Set<ByteSequence> locksToRelease;
 
-    private static final ByteSequence SAMPLE_NAME = ByteSequence.from("sample_name", Charsets.UTF_8);
-    private static final ByteSequence namespace = ByteSequence.from("test-ns/", Charsets.UTF_8);
-    private static final ByteSequence namespace2 = ByteSequence.from("test-ns2/", Charsets.UTF_8);
+    private static final ByteSequence SAMPLE_NAME = ByteSequence.from("sample_name", StandardCharsets.UTF_8);
+    private static final ByteSequence namespace = ByteSequence.from("test-ns/", StandardCharsets.UTF_8);
+    private static final ByteSequence namespace2 = ByteSequence.from("test-ns2/", StandardCharsets.UTF_8);
 
     @BeforeAll
     public static void setUp() {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/TestUtil.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/TestUtil.java
@@ -19,6 +19,7 @@ package io.etcd.jetcd.impl;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
@@ -27,19 +28,16 @@ import io.etcd.jetcd.launcher.EtcdCluster;
 import io.etcd.jetcd.test.EtcdClusterExtension;
 import io.etcd.jetcd.watch.WatchResponse;
 
-import com.google.common.base.Charsets;
 import com.google.protobuf.ByteString;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TestUtil {
 
     public static ByteSequence bytesOf(final String string) {
-        return ByteSequence.from(string, UTF_8);
+        return ByteSequence.from(string, StandardCharsets.UTF_8);
     }
 
     public static ByteString byteStringOf(final String string) {
-        return ByteString.copyFrom(string.getBytes(UTF_8));
+        return ByteString.copyFrom(string.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String randomString() {
@@ -47,7 +45,7 @@ public class TestUtil {
     }
 
     public static ByteSequence randomByteSequence() {
-        return ByteSequence.from(randomString(), Charsets.UTF_8);
+        return ByteSequence.from(randomString(), StandardCharsets.UTF_8);
     }
 
     public static int findNextAvailablePort() throws IOException {

--- a/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandGet.java
+++ b/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandGet.java
@@ -16,6 +16,8 @@
 
 package io.etcd.jetcd.examples.ctl;
 
+import java.nio.charset.StandardCharsets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,8 +27,6 @@ import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 
 import picocli.CommandLine;
-
-import static com.google.common.base.Charsets.UTF_8;
 
 @CommandLine.Command(name = "get", description = "Gets the key")
 class CommandGet implements Runnable {
@@ -45,7 +45,7 @@ class CommandGet implements Runnable {
     public void run() {
         try (Client client = Client.builder().endpoints(main.endpoints).build()) {
             GetResponse getResponse = client.getKVClient().get(
-                ByteSequence.from(key, UTF_8),
+                ByteSequence.from(key, StandardCharsets.UTF_8),
                 GetOption.builder().withRevision(rev).build()).get();
 
             if (getResponse.getKvs().isEmpty()) {
@@ -54,7 +54,7 @@ class CommandGet implements Runnable {
             }
 
             LOGGER.info(key);
-            LOGGER.info(getResponse.getKvs().get(0).getValue().toString(UTF_8));
+            LOGGER.info(getResponse.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8));
         } catch (Exception e) {
             LOGGER.warn(e.getMessage());
         }

--- a/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandPut.java
+++ b/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandPut.java
@@ -16,13 +16,13 @@
 
 package io.etcd.jetcd.examples.ctl;
 
+import java.nio.charset.StandardCharsets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
-
-import com.google.common.base.Charsets;
 
 import picocli.CommandLine;
 
@@ -42,8 +42,8 @@ class CommandPut implements Runnable {
     public void run() {
         try (Client client = Client.builder().endpoints(main.endpoints).build()) {
             client.getKVClient().put(
-                ByteSequence.from(key, Charsets.UTF_8),
-                ByteSequence.from(val, Charsets.UTF_8)).get();
+                ByteSequence.from(key, StandardCharsets.UTF_8),
+                ByteSequence.from(val, StandardCharsets.UTF_8)).get();
 
             LOGGER.info("OK");
         } catch (Exception e) {

--- a/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandWatch.java
+++ b/jetcd-ctl/src/main/java/io/etcd/jetcd/examples/ctl/CommandWatch.java
@@ -16,6 +16,7 @@
 
 package io.etcd.jetcd.examples.ctl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
@@ -29,8 +30,6 @@ import io.etcd.jetcd.Watch.Watcher;
 import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.watch.WatchEvent;
 import io.etcd.jetcd.watch.WatchResponse;
-
-import com.google.common.base.Charsets;
 
 import picocli.CommandLine;
 
@@ -54,15 +53,17 @@ class CommandWatch implements Runnable {
         CountDownLatch latch = new CountDownLatch(maxEvents != null ? maxEvents : Integer.MAX_VALUE);
 
         try (Client client = Client.builder().endpoints(main.endpoints).build()) {
-            ByteSequence watchKey = ByteSequence.from(key, Charsets.UTF_8);
+            ByteSequence watchKey = ByteSequence.from(key, StandardCharsets.UTF_8);
             WatchOption watchOpts = WatchOption.builder().withRevision(rev != null ? rev : 0).build();
 
             Consumer<WatchResponse> consumer = response -> {
                 for (WatchEvent event : response.getEvents()) {
                     LOGGER.info("type={}, key={}, value={}",
                         event.getEventType().toString(),
-                        Optional.ofNullable(event.getKeyValue().getKey()).map(bs -> bs.toString(Charsets.UTF_8)).orElse(""),
-                        Optional.ofNullable(event.getKeyValue().getValue()).map(bs -> bs.toString(Charsets.UTF_8)).orElse(""));
+                        Optional.ofNullable(event.getKeyValue().getKey()).map(bs -> bs.toString(StandardCharsets.UTF_8))
+                            .orElse(""),
+                        Optional.ofNullable(event.getKeyValue().getValue()).map(bs -> bs.toString(StandardCharsets.UTF_8))
+                            .orElse(""));
                 }
 
                 latch.countDown();

--- a/jetcd-grpc/build.gradle
+++ b/jetcd-grpc/build.gradle
@@ -21,7 +21,6 @@ plugins {
 dependencies {
     api libs.slf4j
     api libs.vertxGrpc
-    api libs.guava
     api libs.bundles.grpc
 }
 

--- a/jetcd-launcher/build.gradle
+++ b/jetcd-launcher/build.gradle
@@ -16,6 +16,7 @@
 
 dependencies {
     api libs.slf4j
+    api libs.guava
     api libs.commonsCompress
     api libs.testcontainers
 

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
@@ -24,7 +24,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.testcontainers.containers.Network;
-import org.testcontainers.shaded.com.google.common.base.Strings;
+
+import com.google.common.base.Strings;
 
 public final class Etcd {
     public static final String CONTAINER_IMAGE = "gcr.io/etcd-development/etcd:v3.5.9";

--- a/jetcd-test/build.gradle
+++ b/jetcd-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     api project(':jetcd-launcher')
 
     api libs.slf4j
+    api libs.guava
     api libs.bundles.grpc
     api libs.bundles.grpcTest
 

--- a/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterNameResolver.java
+++ b/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterNameResolver.java
@@ -19,6 +19,7 @@ package io.etcd.jetcd.test;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ public class EtcdClusterNameResolver extends NameResolver {
         synchronized (lock) {
             Preconditions.checkState(this.listener == null, "already started");
             this.executor = SharedResourceHolder.get(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
-            this.listener = Preconditions.checkNotNull(listener, "listener");
+            this.listener = Objects.requireNonNull(listener, "listener");
             resolve();
         }
     }


### PR DESCRIPTION
Avoid adding extra third party dependency 'guava' by replacing methods with equivalent alternatives in standard jdk.

This helps users of etcd since every transitive third party dependency requires more code to be downloaded and might result in dependency conflicts.

fixes #1207