### PR TITLE
build: test with OpenJDK 17

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java-version: [11, 17]
         etcd:
           - gcr.io/etcd-development/etcd:v3.5.9
           - gcr.io/etcd-development/etcd:v3.4.26
@@ -43,7 +44,7 @@ jobs:
       - name: Set Up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build Project
@@ -55,6 +56,7 @@ jobs:
 
           ./gradlew spotlessCheck
           ./gradlew test
+
   publish:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java-version: [11, 17]
         etcd:
           - gcr.io/etcd-development/etcd:v3.5.9
           - gcr.io/etcd-development/etcd:v3.4.26
@@ -51,7 +52,7 @@ jobs:
       - name: Set Up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build Project


### PR DESCRIPTION
Now that jetcd should support OpenJDK 11+, it would be better to test not only OpenJDK 11, but OpenJDK 17 as well.
For example, the issue fixed by #1216 can only be reproduced with OpenJDK 13+.