### PR TITLE
Add OWNERS file for jetcd

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - fanminshi       # Fanmin Shi <fanmin.shi@coreos.com>
+  - lburgazzoli     # Luca Burgazzoli <lburgazzoli@gmail.com>
+  - xiang90         # Xiang Li <xiang.li@coreos.com>
+  - heyitsanthony   # Anthony Romano <anthony.romano@coreos.com>


### PR DESCRIPTION
Sub-task of https://github.com/etcd-io/etcd/issues/16367.

This pull request proposes a layout for the OWNERS file we need to add to each non archived subproject under the etcd-io github organisation as part of the creation of sig-etcd.

Refer to OWNERS documentation: https://www.kubernetes.dev/docs/guide/owners

Note: Once the sig comes online fully and we shift to managing org membership through the kubernetes org bot then we need to consider a follow-up pull request to prune out the old MAINTAINERS file approach.