### PR TITLE
Clean up deprecated method of maintenance

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/Maintenance.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Maintenance.java
@@ -17,16 +17,9 @@
 package io.etcd.jetcd;
 
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
-import io.etcd.jetcd.maintenance.AlarmMember;
-import io.etcd.jetcd.maintenance.AlarmResponse;
-import io.etcd.jetcd.maintenance.DefragmentResponse;
-import io.etcd.jetcd.maintenance.HashKVResponse;
-import io.etcd.jetcd.maintenance.MoveLeaderResponse;
-import io.etcd.jetcd.maintenance.SnapshotResponse;
-import io.etcd.jetcd.maintenance.StatusResponse;
+import io.etcd.jetcd.maintenance.*;
 import io.etcd.jetcd.support.CloseableClient;
 import io.grpc.stub.StreamObserver;
 
@@ -71,16 +64,6 @@ public interface Maintenance extends CloseableClient {
     /**
      * Defragment one member of the cluster by its endpoint.
      *
-     * @param      endpoint the etcd server endpoint.
-     * @return              the response result
-     * @deprecated          use {@link #defragmentMember(String)}
-     */
-    @Deprecated
-    CompletableFuture<DefragmentResponse> defragmentMember(URI endpoint);
-
-    /**
-     * Defragment one member of the cluster by its endpoint.
-     *
      * <p>
      * After compacting the keyspace, the backend database may exhibit internal
      * fragmentation. Any internal fragmentation is space that is free to use
@@ -103,31 +86,10 @@ public interface Maintenance extends CloseableClient {
     /**
      * get the status of a member by its endpoint.
      *
-     * @param      endpoint the etcd server endpoint.
-     * @return              the response result
-     * @deprecated          use {@link #statusMember(String)}
-     */
-    @Deprecated
-    CompletableFuture<StatusResponse> statusMember(URI endpoint);
-
-    /**
-     * get the status of a member by its endpoint.
-     *
      * @param  target the etcd server endpoint.
      * @return        the response result
      */
     CompletableFuture<StatusResponse> statusMember(String target);
-
-    /**
-     * returns a hash of the KV state at the time of the RPC.
-     *
-     * @param      endpoint the etcd server endpoint.
-     * @param      rev      the revision
-     * @return              the response result
-     * @deprecated          use {@link #hashKV(String, long)}
-     */
-    @Deprecated
-    CompletableFuture<HashKVResponse> hashKV(URI endpoint, long rev);
 
     /**
      * returns a hash of the KV state at the time of the RPC.

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/MaintenanceImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/MaintenanceImpl.java
@@ -18,19 +18,12 @@ package io.etcd.jetcd.impl;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.etcd.jetcd.Maintenance;
-import io.etcd.jetcd.api.AlarmRequest;
+import io.etcd.jetcd.api.*;
 import io.etcd.jetcd.api.AlarmType;
-import io.etcd.jetcd.api.DefragmentRequest;
-import io.etcd.jetcd.api.HashKVRequest;
-import io.etcd.jetcd.api.MoveLeaderRequest;
-import io.etcd.jetcd.api.SnapshotRequest;
-import io.etcd.jetcd.api.StatusRequest;
-import io.etcd.jetcd.api.VertxMaintenanceGrpc;
 import io.etcd.jetcd.maintenance.AlarmResponse;
 import io.etcd.jetcd.maintenance.DefragmentResponse;
 import io.etcd.jetcd.maintenance.HashKVResponse;
@@ -79,11 +72,6 @@ final class MaintenanceImpl extends Impl implements Maintenance {
     }
 
     @Override
-    public CompletableFuture<DefragmentResponse> defragmentMember(URI endpoint) {
-        return defragmentMember(endpoint.toString());
-    }
-
-    @Override
     public CompletableFuture<DefragmentResponse> defragmentMember(String target) {
         return this.connectionManager().withNewChannel(
             target,
@@ -93,11 +81,6 @@ final class MaintenanceImpl extends Impl implements Maintenance {
                     .map(DefragmentResponse::new)
                     .toCompletionStage().toCompletableFuture();
             });
-    }
-
-    @Override
-    public CompletableFuture<StatusResponse> statusMember(URI endpoint) {
-        return statusMember(endpoint.toString());
     }
 
     @Override
@@ -117,11 +100,6 @@ final class MaintenanceImpl extends Impl implements Maintenance {
         return completable(
             this.stub.moveLeader(MoveLeaderRequest.newBuilder().setTargetID(transfereeID).build()),
             MoveLeaderResponse::new);
-    }
-
-    @Override
-    public CompletableFuture<HashKVResponse> hashKV(URI endpoint, long rev) {
-        return hashKV(endpoint.toString(), rev);
     }
 
     @Override


### PR DESCRIPTION
This PR want to delete the deprecated method of `Maintenance`  ,there are deprecated in 11/18/2021 and release in the 0.6.1. 