### PR TITLE
check javadoc at PR CI

### DIFF
--- a/gradle/publishing-release.gradle
+++ b/gradle/publishing-release.gradle
@@ -89,6 +89,8 @@ signing {
     sign publishing.publications."${project.name}"
 }
 
+check.dependsOn javadoc
+
 javadoc {
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/DefragmentResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/DefragmentResponse.java
@@ -16,13 +16,11 @@
 
 package io.etcd.jetcd.maintenance;
 
-import java.net.URI;
-
 import io.etcd.jetcd.Maintenance;
 import io.etcd.jetcd.impl.AbstractResponse;
 
 /**
- * DefragmentResponse returned by {@link Maintenance#defragmentMember(URI)} contains a header.
+ * DefragmentResponse returned by {@link Maintenance#defragmentMember(String)} contains a header.
  */
 public class DefragmentResponse extends AbstractResponse<io.etcd.jetcd.api.DefragmentResponse> {
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/HashKVResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/HashKVResponse.java
@@ -16,13 +16,11 @@
 
 package io.etcd.jetcd.maintenance;
 
-import java.net.URI;
-
 import io.etcd.jetcd.Maintenance;
 import io.etcd.jetcd.impl.AbstractResponse;
 
 /**
- * HashKVResponse returned by {@link Maintenance#hashKV(URI, long)}.
+ * HashKVResponse returned by {@link Maintenance#hashKV(String, long)}.
  */
 public class HashKVResponse extends AbstractResponse<io.etcd.jetcd.api.HashKVResponse> {
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
@@ -16,13 +16,11 @@
 
 package io.etcd.jetcd.maintenance;
 
-import java.net.URI;
-
 import io.etcd.jetcd.Maintenance;
 import io.etcd.jetcd.impl.AbstractResponse;
 
 /**
- * StatusResponse returned by {@link Maintenance#statusMember(URI)} contains
+ * StatusResponse returned by {@link Maintenance#statusMember(String)} contains
  * a header, version, dbSize, current leader, raftIndex, and raftTerm.
  */
 public class StatusResponse extends AbstractResponse<io.etcd.jetcd.api.StatusResponse> {


### PR DESCRIPTION
Since https://github.com/etcd-io/jetcd/pull/1234 is merged, Publish Snapshot with main github acion is failed, this PR is work for block in advance ~~with publish to local maven at PR CI.~~

https://github.com/etcd-io/jetcd/actions/runs/6483249273/job/17604772897
```log
/home/runner/work/jetcd/jetcd/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/DefragmentResponse.java:25: error: reference not found

 * DefragmentResponse returned by {@link Maintenance#defragmentMember(URI)} contains a header.
                                         ^
/home/runner/work/jetcd/jetcd/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java:25: error: reference not found
 * StatusResponse returned by {@link Maintenance#statusMember(URI)} contains
> Task :jetcd-core:javadoc
                                     ^
/home/runner/work/jetcd/jetcd/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/HashKVResponse.java:25: error: reference not found
 * HashKVResponse returned by {@link Maintenance#hashKV(URI, long)}.
                                     ^
```

And fix CI.
