### PR TITLE
Complete migration to OWNERS file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make sure commit messages are in the proper format (see below).
 - Push changes in a topic branch to a personal fork of the repository.
 - Submit a pull request to etcd-io/jetcd.
-- The PR must receive a LGTM from at least one maintainer found in the [MAINTAINERS](https://github.com/etcd-io/etcd/blob/master/MAINTAINERS) file.
+- The PR must receive a LGTM from at least one maintainer found in the [OWNERS](https://github.com/etcd-io/jetcd/blob/main/OWNERS) file.
 
 Thanks for contributing!
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,0 @@
-Fanmin Shi <fanmin.shi@coreos.com> (@fanminshi) pkg:*
-Luca Burgazzoli <lburgazzoli@gmail.com> (@lburgazzoli) pkg:*
-Xiang Li <xiang.li@coreos.com> (@xiang90) pkg:*
-Anthony Romano <anthony.romano@coreos.com> (@heyitsanthony) pkg:*


### PR DESCRIPTION
As part of our setup for sig-etcd we intend to adopt the kubernetes project `OWNERS` file approach for managing repository and github org permissions automatically as code.

In https://github.com/etcd-io/jetcd/pull/1230 we introduced the `OWNERS` file for jetcd.

This pull request is a tidy-up to remove the old `MAINTAINERS` file approach.

Sub task under: https://github.com/etcd-io/etcd/issues/16367