### PR TITLE
watcher: Register Exception Handler before watch request

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ commonsIo = "2.15.1"
 commonCompress = "1.25.0"
 autoService = "1.1.1"
 errorprone = "2.23.0"
-vertx = "4.5.0"
+vertx = "4.5.1"
 picocli = "4.7.5"
 restAssured = "5.3.2"
 

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/WatchImpl.java
@@ -178,13 +178,12 @@ final class WatchImpl extends Impl implements Watch {
                     builder.addFilters(WatchCreateRequest.FilterType.NOPUT);
                 }
 
-                rstream = Util.applyRequireLeader(option.withRequireLeader(), stub).watch(stream -> {
+                rstream = Util.applyRequireLeader(option.withRequireLeader(), stub).watchWithExceptionHandler(stream -> {
                     wstream.set(stream);
                     stream.write(WatchRequest.newBuilder().setCreateRequest(builder).build());
-                });
+                }, this::onError);
 
                 rstream.handler(this::onNext);
-                rstream.exceptionHandler(this::onError);
                 rstream.endHandler(event -> onCompleted());
             }
         }


### PR DESCRIPTION
Registers Exception handler before watch request so that if exception happens watch can resume.

Fixes #1261 