### PR TITLE
watcher: Expose isClosed method

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/Watch.java
@@ -227,6 +227,11 @@ public interface Watch extends CloseableClient {
         void close();
 
         /**
+         * Returns if watcher is already closed
+         */
+        boolean isClosed();
+
+        /**
          * Requests the latest revision processed and propagates it to listeners
          */
         void requestProgress();

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/WatchImpl.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/WatchImpl.java
@@ -143,7 +143,8 @@ final class WatchImpl extends Impl implements Watch {
         //
         // ************************
 
-        boolean isClosed() {
+        @Override
+        public boolean isClosed() {
             return this.closed.get() || WatchImpl.this.closed.get();
         }
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/WatchUnitTest.java
@@ -427,8 +427,7 @@ public class WatchUnitTest {
             assertThat(ref.get()).isNotNull();
             assertThat(ref.get()).isInstanceOf(EtcdException.class)
                 .hasMessageContaining(Errors.NO_LEADER_ERROR_MESSAGE);
-            final WatchImpl.WatcherImpl wimpl = (WatchImpl.WatcherImpl) watcher;
-            assertThat(wimpl.isClosed()).isTrue();
+            assertThat(watcher.isClosed()).isTrue();
         }
     }
 }


### PR DESCRIPTION
Expose isClosed method on watcher so that we can restart the watch incase it is closed because of Errors.isHaltError(status) or  Errors.isNoLeaderError(status)