### PR TITLE
jetcd-launcher: allow starting Etcd Container via non-root user on Linux

### DIFF
--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
@@ -58,6 +58,7 @@ public final class Etcd {
         private List<String> additionalArgs;
         private Network network;
         private boolean shouldMountDataDirectory = true;
+        private String user;
 
         public Builder withClusterName(String clusterName) {
             this.clusterName = clusterName;
@@ -114,11 +115,17 @@ public final class Etcd {
                 debug,
                 additionalArgs,
                 network != null ? network : Network.SHARED,
-                shouldMountDataDirectory);
+                shouldMountDataDirectory,
+                user);
         }
 
         public Builder withMountedDataDirectory(boolean shouldMountDataDirectory) {
             this.shouldMountDataDirectory = shouldMountDataDirectory;
+            return this;
+        }
+
+        public Builder withUser(String user) {
+            this.user = user;
             return this;
         }
     }

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterImpl.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/EtcdClusterImpl.java
@@ -43,7 +43,8 @@ public class EtcdClusterImpl implements EtcdCluster {
         boolean debug,
         Collection<String> additionalArgs,
         Network network,
-        boolean shouldMountDataDirectory) {
+        boolean shouldMountDataDirectory,
+        String user) {
 
         this.clusterName = clusterName;
         this.endpoints = IntStream.range(0, nodes)
@@ -57,7 +58,8 @@ public class EtcdClusterImpl implements EtcdCluster {
                 .withDebug(debug)
                 .withAdditionalArgs(additionalArgs)
                 .withNetwork(network)
-                .withShouldMountDataDirectory(shouldMountDataDirectory))
+                .withShouldMountDataDirectory(shouldMountDataDirectory)
+                .withUser(user))
             .collect(toList());
     }
 

--- a/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
+++ b/jetcd-test/src/main/java/io/etcd/jetcd/test/EtcdClusterExtension.java
@@ -168,6 +168,11 @@ public class EtcdClusterExtension implements BeforeAllCallback, BeforeEachCallba
             return this;
         }
 
+        public Builder withUser(String user) {
+            builder.withUser(user);
+            return this;
+        }
+
         public EtcdClusterExtension build() {
             return new EtcdClusterExtension(builder.build());
         }


### PR DESCRIPTION
- For #1310 .
- Allow starting Etcd Container via non-root user on Linux.
- I verified that on the apache/shardingsphere side, this PR can fix the problem that the temporary directory cannot be deleted after shutting down the container. For example, the owner of `/tmp/jetcd_test_etcd0_15814517176251913946/member` will be changed to the Linux user logged in on the current host. Although apache/shardingsphere will not benefit from this change due to the need to stay on the jdk8 runtime baseline.
- At least for Ubuntu WSL 22.04.4, uid `1000` will be the current Linux user. This can be verified with `cat /etc/passwd`. Refer to https://docs.docker.com/engine/reference/run/#user , https://docs.docker.com/engine/security/userns-remap/ and https://www.docker.com/blog/understanding-the-docker-user-instruction/ .
```bash
linghengqian@DESKTOP-2OCN434:~/TwinklingLiftWorks/git/public/shardingsphere$ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
systemd-network:x:100:102:systemd Network Management,,,:/run/systemd:/usr/sbin/nologin
systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd:/usr/sbin/nologin
messagebus:x:102:105::/nonexistent:/usr/sbin/nologin
systemd-timesync:x:103:106:systemd Time Synchronization,,,:/run/systemd:/usr/sbin/nologin
syslog:x:104:111::/home/syslog:/usr/sbin/nologin
_apt:x:105:65534::/nonexistent:/usr/sbin/nologin
uuidd:x:106:112::/run/uuidd:/usr/sbin/nologin
tcpdump:x:107:113::/nonexistent:/usr/sbin/nologin
linghengqian:x:1000:1000:,,,:/home/linghengqian:/bin/bash
usbmux:x:108:46:usbmux daemon,,,:/var/lib/usbmux:/usr/sbin/nologin
rtkit:x:109:117:RealtimeKit,,,:/proc:/usr/sbin/nologin
```
- For other systems, I don't have a local verification environment. To test the current PR in other projects, just execute the following command.
```bash
sdk install java 17.0.11-ms
sdk use java 17.0.11-ms
git clone git@github.com:linghengqian/jetcd.git -b fix-not-root-user
cd ./jetcd/
./gradlew clean publishToMavenLocal
```
- Then use it directly.
```xml
<dependency>
            <groupId>io.etcd</groupId>
            <artifactId>jetcd-test</artifactId>
            <version>0.8.3-fix-not-root-user-SNAPSHOT</version>
            <scope>test</scope>
</dependency>
```