### PR TITLE
chore: switch to quay as gcr is deprecated

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -42,8 +42,8 @@ jobs:
           - 17
           - 21
         etcd:
-          - gcr.io/etcd-development/etcd:v3.5.14
-          - gcr.io/etcd-development/etcd:v3.4.33
+          - quay.io/coreos/etcd:v3.5.14
+          - quay.io/coreos/etcd:v3.4.33
     uses: ./.github/workflows/build.yml
     with:
       javaVersion: "${{ matrix.java-version }}"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,8 +43,8 @@ jobs:
           - 17
           - 21
         etcd:
-          - gcr.io/etcd-development/etcd:v3.5.14
-          - gcr.io/etcd-development/etcd:v3.4.33
+          - quay.io/coreos/etcd:v3.5.14
+          - quay.io/coreos/etcd:v3.4.33
     uses: ./.github/workflows/build.yml
     with:
       javaVersion: "${{ matrix.java-version }}"

--- a/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
+++ b/jetcd-launcher/src/main/java/io/etcd/jetcd/launcher/Etcd.java
@@ -28,7 +28,7 @@ import org.testcontainers.containers.Network;
 import com.google.common.base.Strings;
 
 public final class Etcd {
-    public static final String CONTAINER_IMAGE = "gcr.io/etcd-development/etcd:v3.5.14";
+    public static final String CONTAINER_IMAGE = "gquay.io/coreos/etcd:v3.5.14";
     public static final int ETCD_CLIENT_PORT = 2379;
     public static final int ETCD_PEER_PORT = 2380;
     public static final String ETCD_DATA_DIR = "/data.etcd";

--- a/jetcd-launcher/src/test/resources/log4j2.xml
+++ b/jetcd-launcher/src/test/resources/log4j2.xml
@@ -27,9 +27,6 @@
   <Loggers>
     <!-- package loggers -->
     <Logger name="org.testcontainers" level="INFO"/>
-    <Logger name="🐳 [gcr.io/etcd-development/etcd:v3.3]" level="WARN"/>
-    <Logger name="🐳 [gcr.io/etcd-development/etcd:v3.4]" level="WARN"/>
-    <Logger name="🐳 [gcr.io/etcd-development/etcd:v3.4.7]" level="WARN"/>
     <Logger name="io.etcd.jetcd.internal.infrastructure" level="INFO"/>
     <Logger name="io.etcd.jetcd.launcher.EtcdCluster" level="WARN"/>
 


### PR DESCRIPTION
see https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation

Signed-off-by: Luca Burgazzoli <lburgazzoli@gmail.com>
