### PR TITLE
feat: add fields - raftAppliedIndex , errorsList, dbSizeInUse and isLearner in StatusResponse

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/maintenance/StatusResponse.java
@@ -16,6 +16,8 @@
 
 package io.etcd.jetcd.maintenance;
 
+import java.util.List;
+
 import io.etcd.jetcd.Maintenance;
 import io.etcd.jetcd.impl.AbstractResponse;
 
@@ -72,5 +74,41 @@ public class StatusResponse extends AbstractResponse<io.etcd.jetcd.api.StatusRes
      */
     public long getRaftTerm() {
         return getResponse().getRaftTerm();
+    }
+
+    /**
+     * Returns the current raft applied index of the responding member.
+     *
+     * @return the raft applied index.
+     */
+    public long getRaftAppliedIndex() {
+        return getResponse().getRaftAppliedIndex();
+    }
+
+    /**
+     * Return the information corresponding to the alarms, health and status.
+     *
+     * @return the list of errors
+     */
+    public List<String> getErrorList() {
+        return getResponse().getErrorsList();
+    }
+
+    /**
+     * Returns the size of the backend database logically in use, in bytes, of the responding member.
+     *
+     * @return dbSizeInUse
+     */
+    public long getDbSizeInUse() {
+        return getResponse().getDbSizeInUse();
+    }
+
+    /**
+     * Returns if the member is a raft learner.
+     *
+     * @return if the member is a raft learner
+     */
+    public boolean getIsLearner() {
+        return getResponse().getIsLearner();
     }
 }

--- a/jetcd-core/src/main/proto/rpc.proto
+++ b/jetcd-core/src/main/proto/rpc.proto
@@ -725,6 +725,14 @@ message StatusResponse {
   uint64 raftIndex = 5;
   // raftTerm is the current raft term of the responding member.
   uint64 raftTerm = 6;
+  // raftAppliedIndex is the current raft applied index of the responding member.
+  uint64 raftAppliedIndex = 7;
+  // errors contains alarm/health information and status.
+  repeated string errors = 8;
+  // dbSizeInUse is the size of the backend database logically in use, in bytes, of the responding member.
+  int64 dbSizeInUse = 9;
+  // isLearner indicates if the member is raft learner.
+  bool isLearner = 10;
 }
 
 message AuthEnableRequest {

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/MaintenanceTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/MaintenanceTest.java
@@ -72,6 +72,15 @@ public class MaintenanceTest {
     public void testStatusMember() throws ExecutionException, InterruptedException {
         StatusResponse statusResponse = maintenance.statusMember(endpoints.get(0)).get();
         assertThat(statusResponse.getDbSize()).isGreaterThan(0);
+        assertThat(statusResponse.getRaftIndex()).isGreaterThan(0);
+        assertThat(statusResponse.getRaftAppliedIndex())
+            .isGreaterThan(0)
+            .isLessThanOrEqualTo(statusResponse.getRaftIndex());
+        assertThat(statusResponse.getDbSizeInUse())
+            .isGreaterThan(0)
+            .isLessThanOrEqualTo(statusResponse.getDbSize());
+        assertThat(statusResponse.getIsLearner()).isFalse();
+        assertThat(statusResponse.getErrorList().size()).isEqualTo(0);
     }
 
     @Test

--- a/jetcd-grpc/src/main/proto/rpc.proto
+++ b/jetcd-grpc/src/main/proto/rpc.proto
@@ -725,6 +725,14 @@ message StatusResponse {
   uint64 raftIndex = 5;
   // raftTerm is the current raft term of the responding member.
   uint64 raftTerm = 6;
+  // raftAppliedIndex is the current raft applied index of the responding member.
+  uint64 raftAppliedIndex = 7;
+  // errors contains alarm/health information and status.
+  repeated string errors = 8;
+  // dbSizeInUse is the size of the backend database logically in use, in bytes, of the responding member.
+  int64 dbSizeInUse = 9;
+  // isLearner indicates if the member is raft learner.
+  bool isLearner = 10;
 }
 
 message AuthEnableRequest {


### PR DESCRIPTION
## What this PR does

This PR adds support for retrieving additional fields in StatusResponse
- raftAppliedIndex
-  errorsList
- dbSizeInUse
- isLearner

## Why this is useful

AppliedRaftIndex in comparison with RaftIndex can be used to determine if the PromoteMember operation could be retried
isLearner call in StatusResponse removes the need for another call to MemberList to determine if the member is a learner

## Implementation Details

- Added a fields to the class: StatusResponse
- Updated `testMemberStatus` to verify that the new fields are indeed present and populated

## Related Issues / Discussions

This change was based on discussion in #1499

---

## Checklist

- [x] Code compiles successfully
- [x] Tests added / updated
- [x] Documentation updated (if needed)
- [x] Ready for review

---
