### PR TITLE
Use NettyChannelBuilder to enable blocking calls in callbacks

### DIFF
--- a/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/ClientBuilder.java
@@ -70,6 +70,7 @@ public final class ClientBuilder implements Cloneable {
     private Duration connectTimeout;
     private boolean waitForReady = true;
     private Vertx vertx;
+    private boolean useVertx = false;
 
     ClientBuilder() {
     }
@@ -710,6 +711,25 @@ public final class ClientBuilder implements Cloneable {
     }
 
     /**
+     * Returns whether to use Vertx for gRPC channel creation.
+     *
+     * @return true if using Vertx for gRPC channel creation.
+     */
+    public boolean isUsingVertx() {
+        return useVertx;
+    }
+
+    /**
+     * Use Vertx for gRPC channel creation instead of default grpc-netty.
+     *
+     * @return this builder
+     */
+    public ClientBuilder useVertx() {
+        useVertx = true;
+        return this;
+    }
+
+    /**
      * Gets the Vertx instance.
      *
      * @return the vertx instance.
@@ -729,6 +749,7 @@ public final class ClientBuilder implements Cloneable {
         Preconditions.checkArgument(vertx != null, "vertx can't be null");
 
         this.vertx = vertx;
+        this.useVertx = true;
 
         return this;
     }

--- a/jetcd-core/src/main/java/io/etcd/jetcd/impl/ClientConnectionManager.java
+++ b/jetcd-core/src/main/java/io/etcd/jetcd/impl/ClientConnectionManager.java
@@ -29,6 +29,7 @@ import io.etcd.jetcd.support.Util;
 import io.grpc.*;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.AbstractStub;
 import io.netty.channel.ChannelOption;
 import io.vertx.core.Vertx;
@@ -159,7 +160,15 @@ final class ClientConnectionManager {
             throw new IllegalArgumentException("At least one endpoint should be provided");
         }
 
-        final VertxChannelBuilder channelBuilder = VertxChannelBuilder.forTarget(vertx(), target);
+        final ManagedChannelBuilder channelBuilder;
+        final NettyChannelBuilder nettyChannelBuilder;
+        if (builder.isUsingVertx()) {
+            channelBuilder = VertxChannelBuilder.forTarget(vertx(), target);
+            nettyChannelBuilder = ((VertxChannelBuilder) channelBuilder).nettyBuilder();
+        } else {
+            channelBuilder = NettyChannelBuilder.forTarget(target);
+            nettyChannelBuilder = (NettyChannelBuilder) channelBuilder;
+        }
 
         if (builder.authority() != null) {
             channelBuilder.overrideAuthority(builder.authority());
@@ -168,10 +177,10 @@ final class ClientConnectionManager {
             channelBuilder.maxInboundMessageSize(builder.maxInboundMessageSize());
         }
         if (builder.sslContext() != null) {
-            channelBuilder.nettyBuilder().negotiationType(NegotiationType.TLS);
-            channelBuilder.nettyBuilder().sslContext(builder.sslContext());
+            nettyChannelBuilder.negotiationType(NegotiationType.TLS);
+            nettyChannelBuilder.sslContext(builder.sslContext());
         } else {
-            channelBuilder.nettyBuilder().negotiationType(NegotiationType.PLAINTEXT);
+            nettyChannelBuilder.negotiationType(NegotiationType.PLAINTEXT);
         }
 
         if (builder.keepaliveTime() != null) {
@@ -184,7 +193,7 @@ final class ClientConnectionManager {
             channelBuilder.keepAliveWithoutCalls(builder.keepaliveWithoutCalls());
         }
         if (builder.connectTimeout() != null) {
-            channelBuilder.nettyBuilder().withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS,
+            nettyChannelBuilder.withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                 (int) builder.connectTimeout().toMillis());
         }
 

--- a/jetcd-core/src/test/java/io/etcd/jetcd/impl/ClientBuilderTest.java
+++ b/jetcd-core/src/test/java/io/etcd/jetcd/impl/ClientBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
-import io.vertx.grpc.VertxChannelBuilder;
+import io.grpc.netty.NettyChannelBuilder;
 
 import static io.etcd.jetcd.impl.TestUtil.bytesOf;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,10 +75,10 @@ public class ClientBuilderTest {
     public void testMaxInboundMessageSize() throws URISyntaxException {
         final int value = 1024 + new Random().nextInt(10);
         final ClientBuilder builder = Client.builder().endpoints(new URI("http://127.0.0.1:2379")).maxInboundMessageSize(value);
-        final VertxChannelBuilder channelBuilder = (VertxChannelBuilder) new ClientConnectionManager(builder)
+        final NettyChannelBuilder channelBuilder = (NettyChannelBuilder) new ClientConnectionManager(builder)
             .defaultChannelBuilder();
 
-        assertThat(channelBuilder.nettyBuilder()).hasFieldOrPropertyWithValue("maxInboundMessageSize", value);
+        assertThat(channelBuilder).hasFieldOrPropertyWithValue("maxInboundMessageSize", value);
     }
 
     @Test


### PR DESCRIPTION
It's currently not possible to do blocking calls in listener handlers while preserving back-pressure as that blocks the vertx event loop (see https://github.com/etcd-io/jetcd/issues/1089 https://github.com/etcd-io/jetcd/issues/1285).
Instead of `VertxChannelBuilder`, we can use `NettyChannelBuilder` delegates `onNext`/`onError`/`onCompleted` to a thread-pool with ordering guarantees.
It is OK to do it as the vertx-grpc stubs are just wrappers around the grpc-java ones and don't actually use the vertx loop. So they are compatible with any `ManagedChannelBuilder` (eg. in unit tests `InProcessChannelBuilder` is used).

Alternatives: 
* Rejected: pass responses to an ordered blocking call executor. This solves the blocking issue but breaks the back-pressure chain (see #1558 )
* Future work: use the vertx-grpc-client (https://github.com/etcd-io/jetcd/issues/1372)